### PR TITLE
Add sanitization code for unsupported characters for big query column names

### DIFF
--- a/target_bigquery/target.py
+++ b/target_bigquery/target.py
@@ -307,9 +307,9 @@ class TargetBigQuery(Target):
         th.Property(
             "schema_resolver_version",
             th.IntegerType,
-            default=1,
+            default=2,
             description=(
-                "The version of the schema resolver to use. Defaults to 1. Version 2 uses JSON as a"
+                "The version of the schema resolver to use. Defaults to 2. Version 2 uses JSON as a"
                 " fallback during denormalization. This only has an effect if denormalized=true"
             ),
             allowed_values=[1, 2],


### PR DESCRIPTION
## Problem:

- Special characters other than underscore are not supported in Bigquery.
- Also non ascii characters like ü are not supported.

## Solution implemented:

- Sanitisation function to remove replace spaces and special characters with underscore.
- Replace non ascii characters with ascii equivalent -> eg, ü with u