### PR TITLE
[PQ-3138] [feat] support table_name_prefix and connector_name_prefix for table naming

### DIFF
--- a/target_bigquery/core.py
+++ b/target_bigquery/core.py
@@ -405,12 +405,9 @@ class BaseBigQuerySink(BatchSink):
 
     @property
     def table_name(self) -> str:
-        """Returns the table name, optionally prefixed with table_name_prefix and connector_name_prefix."""
+        """Returns the table name, optionally prefixed with table_name_prefix."""
         base = self.stream_name.lower().replace("-", "_").replace(".", "_")
         prefix = self.config.get("table_name_prefix", "")
-        connector = self.config.get("connector_name_prefix", "")
-        if connector:
-            return f"{prefix}{connector}_{base}"
         if prefix:
             return f"{prefix}{base}"
         return base

--- a/target_bigquery/core.py
+++ b/target_bigquery/core.py
@@ -405,8 +405,15 @@ class BaseBigQuerySink(BatchSink):
 
     @property
     def table_name(self) -> str:
-        """Returns the table name."""
-        return self.stream_name.lower().replace("-", "_").replace(".", "_")
+        """Returns the table name, optionally prefixed with table_name_prefix and connector_name_prefix."""
+        base = self.stream_name.lower().replace("-", "_").replace(".", "_")
+        prefix = self.config.get("table_name_prefix", "")
+        connector = self.config.get("connector_name_prefix", "")
+        if connector:
+            return f"{prefix}{connector}_{base}"
+        if prefix:
+            return f"{prefix}{base}"
+        return base
 
     @property
     def max_size(self) -> int:

--- a/target_bigquery/target.py
+++ b/target_bigquery/target.py
@@ -209,12 +209,6 @@ class TargetBigQuery(Target):
             required=False,
         ),
         th.Property(
-            "connector_name_prefix",
-            th.StringType,
-            description="A connector/source name prepended after table_name_prefix (e.g. 'exactonline').",
-            required=False,
-        ),
-        th.Property(
             "options",
             th.ObjectType(
                 th.Property(

--- a/target_bigquery/target.py
+++ b/target_bigquery/target.py
@@ -203,6 +203,18 @@ class TargetBigQuery(Target):
             required=False,
         ),
         th.Property(
+            "table_name_prefix",
+            th.StringType,
+            description="A fixed prefix prepended to all table names (e.g. 'bronze_').",
+            required=False,
+        ),
+        th.Property(
+            "connector_name_prefix",
+            th.StringType,
+            description="A connector/source name prepended after table_name_prefix (e.g. 'exactonline').",
+            required=False,
+        ),
+        th.Property(
             "options",
             th.ObjectType(
                 th.Property(


### PR DESCRIPTION
## Reference Ticket

- PQ Ticket: PQ-3138

## Description

The BigQuery fixed dataset feature requires support for multiple connectors writing to the same dataset with distinct table names. This change adds configuration properties to enable flexible table naming with connector-specific and custom prefixes.

Updated `table_name` property in `core.py` to construct table names with optional `table_name_prefix` (e.g., 'bronze_') and `connector_name_prefix` (e.g., 'exactonline'). Added corresponding configuration schema properties in `target.py` to allow users to configure these prefixes.

## Tests

Manual verification performed.