### PR TITLE
[PQ-3407] [refactor] switch BQ dataset & table creation to get-then-create pattern

### DIFF
--- a/target_bigquery/core.py
+++ b/target_bigquery/core.py
@@ -172,7 +172,7 @@ class BigQueryTable:
         BigQuery's Admin Activity audit logs on every sync run."""
         if not hasattr(self, "_dataset"):
             try:
-                dataset = client.get_dataset(self.as_dataset_ref())
+                dataset = client.get_dataset(self.as_dataset(**kwargs["dataset"]))
                 if dataset.location != kwargs["dataset"]["location"]:
                     raise Exception(
                         f"Location of existing dataset {dataset.dataset_id} ({dataset.location}) "

--- a/target_bigquery/core.py
+++ b/target_bigquery/core.py
@@ -39,7 +39,7 @@ from tempfile import TemporaryFile
 from textwrap import dedent, indent
 from typing import IO, TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
-from google.api_core.exceptions import Conflict
+from google.api_core.exceptions import NotFound
 from google.cloud import bigquery, bigquery_storage_v1, storage
 from google.cloud.bigquery import SchemaField
 from google.cloud.bigquery.table import TimePartitioning, TimePartitioningType
@@ -165,32 +165,35 @@ class BigQueryTable:
 
         This is a convenience method that wraps the creation of a dataset and
         table in a single method call. It is idempotent and will not create
-        a new table if one already exists."""
+        a new table if one already exists.
+
+        Uses a get-then-create pattern (mirroring `create_bucket_if_not_exists`
+        in gcs_stage.py) to avoid emitting spurious 409 Conflict entries into
+        BigQuery's Admin Activity audit logs on every sync run."""
         if not hasattr(self, "_dataset"):
             try:
-                self._dataset = client.create_dataset(
-                    self.as_dataset(**kwargs["dataset"]), exists_ok=False
-                )
-            except Conflict:
-                dataset = client.get_dataset(self.as_dataset(**kwargs["dataset"]))
-                if dataset.location != kwargs["dataset"]["location"]:
+                self._dataset = client.get_dataset(self.as_dataset_ref())
+                if self._dataset.location != kwargs["dataset"]["location"]:
                     raise Exception(
-                        f"Location of existing dataset {dataset.dataset_id} ({dataset.location}) "
+                        f"Location of existing dataset {self._dataset.dataset_id} ({self._dataset.location}) "
                         f"does not match specified location: {kwargs['dataset']['location']}"
                     )
-                else:
-                    self._dataset = dataset
+            except NotFound:
+                self._dataset = client.create_dataset(
+                    self.as_dataset(**kwargs["dataset"])
+                )
+                # Wait for eventual consistency
+                time.sleep(5)
         if not hasattr(self, "_table"):
             try:
+                self._table = client.get_table(self.as_ref())
+            except NotFound:
                 self._table = client.create_table(
                     self.as_table(
                         apply_transforms and self.ingestion_strategy != IngestionStrategy.FIXED,
                         **kwargs["table"],
                     )
                 )
-            except Conflict:
-                self._table = client.get_table(self.as_ref())
-            else:
                 # Wait for eventual consistency
                 time.sleep(5)
         return self._dataset, self._table

--- a/target_bigquery/core.py
+++ b/target_bigquery/core.py
@@ -172,12 +172,13 @@ class BigQueryTable:
         BigQuery's Admin Activity audit logs on every sync run."""
         if not hasattr(self, "_dataset"):
             try:
-                self._dataset = client.get_dataset(self.as_dataset_ref())
-                if self._dataset.location != kwargs["dataset"]["location"]:
+                dataset = client.get_dataset(self.as_dataset_ref())
+                if dataset.location != kwargs["dataset"]["location"]:
                     raise Exception(
-                        f"Location of existing dataset {self._dataset.dataset_id} ({self._dataset.location}) "
+                        f"Location of existing dataset {dataset.dataset_id} ({dataset.location}) "
                         f"does not match specified location: {kwargs['dataset']['location']}"
                     )
+                self._dataset = dataset
             except NotFound:
                 self._dataset = client.create_dataset(
                     self.as_dataset(**kwargs["dataset"])

--- a/target_bigquery/core.py
+++ b/target_bigquery/core.py
@@ -39,7 +39,7 @@ from tempfile import TemporaryFile
 from textwrap import dedent, indent
 from typing import IO, TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
-from google.api_core.exceptions import NotFound
+from google.api_core.exceptions import Conflict, NotFound
 from google.cloud import bigquery, bigquery_storage_v1, storage
 from google.cloud.bigquery import SchemaField
 from google.cloud.bigquery.table import TimePartitioning, TimePartitioningType
@@ -178,13 +178,25 @@ class BigQueryTable:
                         f"Location of existing dataset {dataset.dataset_id} ({dataset.location}) "
                         f"does not match specified location: {kwargs['dataset']['location']}"
                     )
-                self._dataset = dataset
+                else:
+                    self._dataset = dataset
             except NotFound:
-                self._dataset = client.create_dataset(
-                    self.as_dataset(**kwargs["dataset"])
-                )
-                # Wait for eventual consistency
-                time.sleep(5)
+                try:
+                    self._dataset = client.create_dataset(
+                        self.as_dataset(**kwargs["dataset"]), exists_ok=False
+                    )
+                except Conflict:
+                    # Race: another process created the dataset between our
+                    # get_dataset (above, which returned NotFound) and this
+                    # create. Re-fetch and validate location, mirroring the
+                    # primary-path validation.
+                    dataset = client.get_dataset(self.as_dataset(**kwargs["dataset"]))
+                    if dataset.location != kwargs["dataset"]["location"]:
+                        raise Exception(
+                            f"Location of existing dataset {dataset.dataset_id} ({dataset.location}) "
+                            f"does not match specified location: {kwargs['dataset']['location']}"
+                        )
+                    self._dataset = dataset
         if not hasattr(self, "_table"):
             try:
                 self._table = client.get_table(self.as_ref())
@@ -193,7 +205,8 @@ class BigQueryTable:
                     self.as_table(
                         apply_transforms and self.ingestion_strategy != IngestionStrategy.FIXED,
                         **kwargs["table"],
-                    )
+                    ),
+                    exists_ok=True,
                 )
                 # Wait for eventual consistency
                 time.sleep(5)


### PR DESCRIPTION
## Ticket

- PQ Ticket: [PQ-3407](https://www.notion.so/peliqan/target-bigquery-switch-BQ-dataset-table-creation-to-get-then-create-pattern-35f1aa9b387981c79615e2c86ee13870)

## Description

Wally reported a flood of `Already Exists: Table` errors in their BigQuery audit logs during ELT syncs, creating noise. Example:

```
Already Exists: Table wallyai:org_<hash>.bronze_<hash>_exactonline_<stream>
```

One entry per stream per sync (job type `insert` = BQ REST `tables.insert`). With ~60 Exact Online streams this produces ~60 entries per sync run.

### Root cause

`BigQueryTable.create_table()` in `target_bigquery/core.py` used an eager **create-then-catch-Conflict** pattern for both the dataset and the table. Each per-stream sink call hit a 409 if the resource already existed; Python caught the exception and recovered via `get_dataset` / `get_table`, but BigQuery still recorded the failed REST call in its Admin Activity audit log.

This is BQ audit log noise only - no functional error, no data loss. The loader recovers cleanly and all four load methods (storage_write_api, batch_job, streaming_insert, gcs_stage) use the table reference directly afterwards.

### Fix

Switch `BigQueryTable.create_table()` to **get-then-create**:

1. **Dataset:** try `client.get_dataset(...)` first; on `NotFound`, call `client.create_dataset(...)`. The existing location-mismatch validation is preserved against the get result. A nested `Conflict` catcher around the create handles the race window where another process creates the dataset between our get and create.
2. **Table:** try `client.get_table(...)` first; on `NotFound`, call `client.create_table(..., exists_ok=True)`. Tables don't have a location attribute, so `exists_ok=True` is sufficient for the race case.

Reads (`tables.get`, `datasets.get`) are not recorded in BigQuery's Admin Activity audit logs (those only capture writes), so on every run after the first, the audit log noise is eliminated.

This mirrors the get-then-create approach already used for GCS buckets in `gcs_stage.py` -> `create_bucket_if_not_exists()` (PR #67, commit `faddcfc`).

Note: `client.create_dataset(..., exists_ok=True)` is NOT a viable substitute - the SDK still issues the POST `datasets.insert` first and only suppresses the Python exception, so the 409 still lands in BQ logs.

## Verification

Deployed to staging, ran consecutive syncs against the same dataset (`peliqan:bigquery_test_pq_3407_with_fix`) and queried BigQuery Admin Activity audit logs.

**Before fix** (sync against pre-existing tables):
```
14:32:21  ERROR   InsertTable  fixed_log_noise_google_sheets_spreadsheet_metadata  Already Exists
14:32:22  NOTICE  InsertTable  ..._spreadsheet_metadata__1778855541                OK   (temp)
14:32:29  ERROR   InsertTable  fixed_log_noise_google_sheets_export                Already Exists
14:32:30  NOTICE  InsertTable  ..._export__1778855550                              OK   (temp)
14:32:38  ERROR   InsertTable  fixed_log_noise_google_sheets_sheet_metadata        Already Exists
14:32:38  NOTICE  InsertTable  ..._sheet_metadata__1778855558                      OK   (temp)
14:32:46  ERROR   InsertTable  fixed_log_noise_google_sheets_sheets_loaded         Already Exists
14:32:46  NOTICE  InsertTable  ..._sheets_loaded__1778855566                       OK   (temp)
```
4 streams = 4 `Already Exists` errors per sync run.

**After fix** (sync against the same pre-existing tables, with patched code deployed):
```
14:46:48  NOTICE  InsertTable  ..._spreadsheet_metadata__1778856408  OK   (temp)
14:46:57  NOTICE  InsertTable  ..._export__1778856416                OK   (temp)
14:47:05  NOTICE  InsertTable  ..._sheet_metadata__1778856424        OK   (temp)
14:47:13  NOTICE  InsertTable  ..._sheets_loaded__1778856433         OK   (temp)
```
0 errors. The main tables produced no audit entries at all (silent `tables.get` reads, not logged in Admin Activity). Only the always-fresh temp tables produced `InsertTable` notices, which is expected.

## Tests

- [x] Syntax-checked locally (`python3 -m ast` on `core.py`).
- [x] Manual verification on staging: pre-existing dataset+tables, post-fix sync produces zero `Already Exists` entries (see Verification above).
- [x] Manual verification on staging: fresh dataset path still creates dataset and tables correctly with the configured location.
- [x] Confirmed via SDK source that `create_dataset(..., exists_ok=True)` would still POST and log the 409 (would not solve the noise).