### PR TITLE
[PQ-3545] [Feat]: handle DELETERECORD — batched row deletion

### DIFF
--- a/target_bigquery/target.py
+++ b/target_bigquery/target.py
@@ -20,6 +20,7 @@ from singer_sdk import typing as th
 from singer_sdk.target_base import Target
 
 from target_bigquery.batch_job import BigQueryBatchJobDenormalizedSink, BigQueryBatchJobSink
+from google.api_core.exceptions import NotFound
 from google.cloud import bigquery
 
 from target_bigquery.core import (
@@ -569,16 +570,18 @@ class TargetBigQuery(Target):
                 worker = self.workers.pop()
             for sink in self._sinks_active.values():
                 sink.clean_up()
-            # Apply buffered DELETERECORDs after upserts (clean_up) so an upsert
-            # + delete of the same key in one run ends deleted. Only at
-            # end-of-pipe, so deletes run once with the full buffer.
-            if self._delete_buffer:
-                self._flush_deletes()
         else:
             for worker in self.workers:
                 worker.join()
             for sink in self._sinks_active.values():
                 sink.pre_state_hook()
+        # Apply buffered DELETERECORDs *before* advancing state, so the bookmark
+        # never moves past deletes that were not applied. At end-of-pipe this runs
+        # after the clean_up() upserts above (an upsert + delete of the same key in
+        # one run ends deleted). A real delete failure raises here, so the state
+        # write below is skipped and the tap replays the deletes on the next run.
+        if self._delete_buffer:
+            self._flush_deletes()
         if state:
             self._write_state_message(state)
         self._reset_max_record_age()
@@ -586,7 +589,14 @@ class TargetBigQuery(Target):
     def _flush_deletes(self) -> None:
         """Apply buffered DELETERECORDs as one batched, parameterized DELETE per
         table. Storage-mode-aware (FIXED -> JSON_VALUE(data,...), DENORMALIZED ->
-        real columns) and best-effort: a failed DELETE is logged, never raised."""
+        real columns).
+
+        Error policy mirrors target-postgres: a delete that cannot be *applied* is
+        a best-effort skip -- a key matching no rows is not an error in BigQuery
+        (0 rows affected, no exception), and a missing table/dataset (NotFound,
+        e.g. a stream never synced) is logged and skipped. Any other failure
+        (connection, credentials, permission, quota, bad SQL) is raised so the
+        caller does not advance the bookmark past deletes that never landed."""
         client = bigquery_client_factory(self._credentials)
         denormalized = self.config.get("denormalized", False)
         project, dataset = self.config["project"], self.config["dataset"]
@@ -624,9 +634,15 @@ class TargetBigQuery(Target):
                 self.logger.info(
                     "delete-sync: removed up to %d row(s) from %s", len(vals), name
                 )
-            except Exception as e:  # best-effort: never fail the pipeline on a delete
+            except NotFound:
+                # Table/dataset absent (e.g. a stream that was never synced). The
+                # delete cannot apply; skip best-effort and continue other streams.
                 self.logger.warning(
-                    "delete-sync: DELETE failed for %s: %s", name, e
+                    "delete-sync: table %s not found; skipping its deletes", name
                 )
+                continue
+            # Any other exception (connection, credentials, permission, quota, bad
+            # SQL) propagates: drain_all aborts before writing state, so the
+            # bookmark is not advanced and the tap replays these deletes next run.
 
         self._delete_buffer.clear()

--- a/target_bigquery/target.py
+++ b/target_bigquery/target.py
@@ -29,6 +29,7 @@ from target_bigquery.core import (
     BigQueryCredentials,
     ParType,
     bigquery_client_factory,
+    transform_column_name,
 )
 from target_bigquery.gcs_stage import BigQueryGcsStagingDenormalizedSink, BigQueryGcsStagingSink
 from target_bigquery.storage_write import (
@@ -601,12 +602,17 @@ class TargetBigQuery(Target):
         denormalized = self.config.get("denormalized", False)
         project, dataset = self.config["project"], self.config["dataset"]
         prefix = self.config.get("table_name_prefix", "")
+        transforms = self.config.get("column_name_transforms", {})
 
         def accessor(col: str) -> str:
             # Compare as text: JSON_VALUE returns STRING; CAST aligns typed columns
             # with the str()-rendered parameter values.
             if denormalized:
-                return f"CAST(`{col}` AS STRING)"
+                # Denormalized writes store columns under the transformed name
+                # (core.SchemaTranslator.translate_record); apply the same
+                # transform so the delete predicate targets the real column.
+                physical = transform_column_name(col, **{**transforms, "quote": False})
+                return f"CAST(`{physical}` AS STRING)"
             return f"JSON_VALUE(data, '$.{col}')"
 
         # Reuse the write-path batch size (baserow -> 5000, default fallback

--- a/target_bigquery/target.py
+++ b/target_bigquery/target.py
@@ -325,6 +325,10 @@ class TargetBigQuery(Target):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.max_parallelism = 1
+        # Buffer for DELETERECORD Singer messages keyed by stream name.
+        # Populated in _process_unknown_message; flushed once at end-of-pipe
+        # after all sink.clean_up() calls so upserts always land before deletes.
+        self._delete_buffer: dict = {}
         (
             self.proc_cls,
             self.pipe_cls,
@@ -491,6 +495,28 @@ class TargetBigQuery(Target):
         if not existing_sink:
             return self.add_sink(stream_name, schema, key_properties)
         return existing_sink
+
+    # ------------------------------------------------------------------ #
+    # delete-sync support                                                  #
+    # ------------------------------------------------------------------ #
+
+    supports_delete_sync: bool = True
+    """Advertises delete-sync capability to baserow's target-support gate."""
+
+    def _process_unknown_message(self, message_dict: dict) -> None:
+        """Intercept DELETERECORD messages; delegate everything else to the SDK.
+
+        DELETERECORD is a Peliqan Singer extension not in the SDK's
+        SingerMessageType enum, so the SDK routes it here.  We buffer the
+        record keyed by stream; _flush_deletes() drains the buffer at
+        end-of-pipe, after all sink.clean_up() upserts have completed.
+        """
+        if message_dict.get("type") == "DELETERECORD":
+            stream = message_dict.get("stream", "")
+            record = message_dict.get("record", {})
+            self._delete_buffer.setdefault(stream, []).append(record)
+            return
+        super()._process_unknown_message(message_dict)
 
     def drain_one(self, sink: Sink) -> None:  # type: ignore
         """Drain a sink. Includes a hook to manage the worker pool and notifications."""

--- a/target_bigquery/target.py
+++ b/target_bigquery/target.py
@@ -609,6 +609,12 @@ class TargetBigQuery(Target):
                 return f"CAST(`{col}` AS STRING)"
             return f"JSON_VALUE(data, '$.{col}')"
 
+        # Reuse the write-path batch size (baserow -> 5000, default fallback
+        # 10_000). The values ride in a query parameter so query length is not the
+        # limit, but chunking keeps each request well under BigQuery's 10 MB cap
+        # and emits one DELETE per chunk (DML-quota friendly).
+        batch_size = self.config.get("batch_size", 10_000)
+
         for stream, records in self._delete_buffer.items():
             if not records:
                 continue
@@ -626,11 +632,15 @@ class TargetBigQuery(Target):
                 vals = ["\u001f".join(str(r[c]) for c in cols) for r in records]
 
             sql = f"DELETE FROM {escaped} WHERE {key_expr} IN UNNEST(@vals)"
-            job_config = bigquery.QueryJobConfig(
-                query_parameters=[bigquery.ArrayQueryParameter("vals", "STRING", vals)]
-            )
             try:
-                client.query(sql, job_config=job_config).result()
+                for start in range(0, len(vals), batch_size):
+                    chunk = vals[start:start + batch_size]
+                    job_config = bigquery.QueryJobConfig(
+                        query_parameters=[
+                            bigquery.ArrayQueryParameter("vals", "STRING", chunk)
+                        ]
+                    )
+                    client.query(sql, job_config=job_config).result()
                 self.logger.info(
                     "delete-sync: removed up to %d row(s) from %s", len(vals), name
                 )

--- a/target_bigquery/target.py
+++ b/target_bigquery/target.py
@@ -20,7 +20,15 @@ from singer_sdk import typing as th
 from singer_sdk.target_base import Target
 
 from target_bigquery.batch_job import BigQueryBatchJobDenormalizedSink, BigQueryBatchJobSink
-from target_bigquery.core import BaseBigQuerySink, BaseWorker, BigQueryCredentials, ParType
+from google.cloud import bigquery
+
+from target_bigquery.core import (
+    BaseBigQuerySink,
+    BaseWorker,
+    BigQueryCredentials,
+    ParType,
+    bigquery_client_factory,
+)
 from target_bigquery.gcs_stage import BigQueryGcsStagingDenormalizedSink, BigQueryGcsStagingSink
 from target_bigquery.storage_write import (
     BigQueryStorageWriteDenormalizedSink,
@@ -561,6 +569,11 @@ class TargetBigQuery(Target):
                 worker = self.workers.pop()
             for sink in self._sinks_active.values():
                 sink.clean_up()
+            # Apply buffered DELETERECORDs after upserts (clean_up) so an upsert
+            # + delete of the same key in one run ends deleted. Only at
+            # end-of-pipe, so deletes run once with the full buffer.
+            if self._delete_buffer:
+                self._flush_deletes()
         else:
             for worker in self.workers:
                 worker.join()
@@ -569,3 +582,51 @@ class TargetBigQuery(Target):
         if state:
             self._write_state_message(state)
         self._reset_max_record_age()
+
+    def _flush_deletes(self) -> None:
+        """Apply buffered DELETERECORDs as one batched, parameterized DELETE per
+        table. Storage-mode-aware (FIXED -> JSON_VALUE(data,...), DENORMALIZED ->
+        real columns) and best-effort: a failed DELETE is logged, never raised."""
+        client = bigquery_client_factory(self._credentials)
+        denormalized = self.config.get("denormalized", False)
+        project, dataset = self.config["project"], self.config["dataset"]
+        prefix = self.config.get("table_name_prefix", "")
+
+        def accessor(col: str) -> str:
+            # Compare as text: JSON_VALUE returns STRING; CAST aligns typed columns
+            # with the str()-rendered parameter values.
+            if denormalized:
+                return f"CAST(`{col}` AS STRING)"
+            return f"JSON_VALUE(data, '$.{col}')"
+
+        for stream, records in self._delete_buffer.items():
+            if not records:
+                continue
+            name = prefix + stream.lower().replace("-", "_").replace(".", "_")
+            escaped = f"`{project}`.`{dataset}`.`{name}`"
+            cols = list(records[0].keys())  # stable column order across the batch
+
+            if len(cols) == 1:
+                key_expr = accessor(cols[0])
+                vals = [str(r[cols[0]]) for r in records]
+            else:
+                # Composite key: join per-column text with the unit-separator
+                # control char (assumed absent from GUID/int/text key values).
+                key_expr = "CONCAT(" + ", '\\u001f', ".join(accessor(c) for c in cols) + ")"
+                vals = ["\u001f".join(str(r[c]) for c in cols) for r in records]
+
+            sql = f"DELETE FROM {escaped} WHERE {key_expr} IN UNNEST(@vals)"
+            job_config = bigquery.QueryJobConfig(
+                query_parameters=[bigquery.ArrayQueryParameter("vals", "STRING", vals)]
+            )
+            try:
+                client.query(sql, job_config=job_config).result()
+                self.logger.info(
+                    "delete-sync: removed up to %d row(s) from %s", len(vals), name
+                )
+            except Exception as e:  # best-effort: never fail the pipeline on a delete
+                self.logger.warning(
+                    "delete-sync: DELETE failed for %s: %s", name, e
+                )
+
+        self._delete_buffer.clear()

--- a/target_bigquery/tests/test_utils.py
+++ b/target_bigquery/tests/test_utils.py
@@ -804,6 +804,20 @@ def test_flush_denormalized_composite_pk():
     assert _vals(client) == ["1\u001f2"]
 
 
+def test_flush_denormalized_applies_column_transform():
+    # baserow runs BigQuery denormalized with add_underscore_when_invalid, so a
+    # digit-leading key is stored as a `_`-prefixed column; the delete must match.
+    _, client = _run_flush(
+        {"Accounts": [{"123id": "a1"}]},
+        denormalized=True,
+        extra_config={"column_name_transforms": {"add_underscore_when_invalid": True}},
+    )
+    assert _sql(client) == (
+        "DELETE FROM `p`.`d`.`accounts` WHERE CAST(`_123id` AS STRING) IN UNNEST(@vals)"
+    )
+    assert _vals(client) == ["a1"]
+
+
 def test_flush_chunks_by_batch_size():
     records = [{"id": f"a{i}"} for i in range(5)]
     _, client = _run_flush({"Accounts": records}, extra_config={"batch_size": 2})

--- a/target_bigquery/tests/test_utils.py
+++ b/target_bigquery/tests/test_utils.py
@@ -804,13 +804,48 @@ def test_flush_denormalized_composite_pk():
     assert _vals(client) == ["1\u001f2"]
 
 
-def test_flush_is_best_effort_and_clears_buffer():
-    t, client = _run_flush(
-        {"Accounts": [{"id": "a1"}]}, query_side_effect=Exception("boom")
-    )
-    # No exception propagated, buffer drained.
-    assert client.query.call_count == 1
-    assert t._delete_buffer == {}
+def test_flush_skips_missing_table_and_continues():
+    # NotFound (table/dataset absent) is a best-effort skip; other streams still run.
+    from google.api_core.exceptions import NotFound
+
+    t = _bare_target(buffer={"Gone": [{"id": "x"}], "Accounts": [{"id": "a1"}]})
+    client = MagicMock()
+    client.query.side_effect = [NotFound("missing"), MagicMock()]
+    with patch("target_bigquery.target.bigquery_client_factory", return_value=client):
+        t._flush_deletes()  # must not raise
+    assert client.query.call_count == 2  # second stream still attempted
+    assert t._delete_buffer == {}  # cleared after a clean pass
+
+
+def test_flush_raises_on_real_error_and_keeps_buffer():
+    # A real failure (connection/credential/etc.) must propagate so state never
+    # advances, and the buffer is NOT cleared.
+    t = _bare_target(buffer={"Accounts": [{"id": "a1"}]})
+    client = MagicMock()
+    client.query.side_effect = Exception("connection reset")
+    with patch("target_bigquery.target.bigquery_client_factory", return_value=client):
+        with pytest.raises(Exception):
+            t._flush_deletes()
+    assert t._delete_buffer == {"Accounts": [{"id": "a1"}]}
+
+
+def test_drain_all_does_not_write_state_when_delete_fails():
+    # The bookmark must not advance past a delete that failed: a raising flush
+    # aborts drain_all before _write_state_message.
+    t = _bare_target(buffer={"Accounts": [{"id": "a1"}]})
+    t._latest_state = {"bookmarks": {"x": 1}}
+    t._sinks_active = {}
+    t.workers = []
+    t.max_parallelism = 1
+    t._drain_all = MagicMock()
+    t._write_state_message = MagicMock()
+    t._reset_max_record_age = MagicMock()
+    client = MagicMock()
+    client.query.side_effect = Exception("creds error")
+    with patch("target_bigquery.target.bigquery_client_factory", return_value=client):
+        with pytest.raises(Exception):
+            t.drain_all(is_endofpipe=True)
+    t._write_state_message.assert_not_called()
 
 
 def test_flush_one_query_per_stream():

--- a/target_bigquery/tests/test_utils.py
+++ b/target_bigquery/tests/test_utils.py
@@ -4,7 +4,7 @@ import pytest
 import singer_sdk.typing as th
 from google.cloud.bigquery import SchemaField
 
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 from target_bigquery.core import SchemaTranslator, bigquery_type, transform_column_name, BigQueryTable, IngestionStrategy
 from target_bigquery.proto_gen import proto_schema_factory_v2
@@ -742,4 +742,95 @@ def test_process_unknown_message_raises_for_other_types():
     t = _bare_target()
     with pytest.raises(ValueError):
         t._process_unknown_message({"type": "SOMETHING_ELSE"})
+    assert t._delete_buffer == {}
+
+
+def _run_flush(buffer, denormalized=False, extra_config=None, query_side_effect=None):
+    config = {"project": "p", "dataset": "d", "denormalized": denormalized}
+    if extra_config:
+        config.update(extra_config)
+    t = _bare_target(config=config, buffer=buffer)
+    client = MagicMock()
+    if query_side_effect is not None:
+        client.query.side_effect = query_side_effect
+    with patch("target_bigquery.target.bigquery_client_factory", return_value=client):
+        t._flush_deletes()
+    return t, client
+
+
+def _sql(client):
+    return client.query.call_args.args[0]
+
+
+def _vals(client):
+    return client.query.call_args.kwargs["job_config"].query_parameters[0].values
+
+
+def test_flush_fixed_single_pk():
+    t, client = _run_flush({"Accounts": [{"id": "a1"}, {"id": "a2"}]}, denormalized=False)
+    assert client.query.call_count == 1
+    assert _sql(client) == (
+        "DELETE FROM `p`.`d`.`accounts` "
+        "WHERE JSON_VALUE(data, '$.id') IN UNNEST(@vals)"
+    )
+    assert _vals(client) == ["a1", "a2"]
+    assert t._delete_buffer == {}
+
+
+def test_flush_fixed_composite_pk():
+    _, client = _run_flush({"Journals": [{"id": "g1", "division": 100}]}, denormalized=False)
+    assert _sql(client) == (
+        "DELETE FROM `p`.`d`.`journals` WHERE "
+        "CONCAT(JSON_VALUE(data, '$.id'), '\\u001f', JSON_VALUE(data, '$.division')) "
+        "IN UNNEST(@vals)"
+    )
+    assert _vals(client) == ["g1\u001f100"]
+
+
+def test_flush_denormalized_single_pk():
+    _, client = _run_flush({"Accounts": [{"id": "a1"}]}, denormalized=True)
+    assert _sql(client) == (
+        "DELETE FROM `p`.`d`.`accounts` WHERE CAST(`id` AS STRING) IN UNNEST(@vals)"
+    )
+    assert _vals(client) == ["a1"]
+
+
+def test_flush_denormalized_composite_pk():
+    _, client = _run_flush({"Inv": [{"a": 1, "b": 2}]}, denormalized=True)
+    assert _sql(client) == (
+        "DELETE FROM `p`.`d`.`inv` WHERE "
+        "CONCAT(CAST(`a` AS STRING), '\\u001f', CAST(`b` AS STRING)) IN UNNEST(@vals)"
+    )
+    assert _vals(client) == ["1\u001f2"]
+
+
+def test_flush_is_best_effort_and_clears_buffer():
+    t, client = _run_flush(
+        {"Accounts": [{"id": "a1"}]}, query_side_effect=Exception("boom")
+    )
+    # No exception propagated, buffer drained.
+    assert client.query.call_count == 1
+    assert t._delete_buffer == {}
+
+
+def test_flush_one_query_per_stream():
+    _, client = _run_flush(
+        {"Accounts": [{"id": "a1"}], "Contacts": [{"id": "c1"}]}
+    )
+    assert client.query.call_count == 2
+    sqls = " ".join(c.args[0] for c in client.query.call_args_list)
+    assert "`p`.`d`.`accounts`" in sqls
+    assert "`p`.`d`.`contacts`" in sqls
+
+
+def test_flush_applies_prefix_and_sanitizes_table_name():
+    _, client = _run_flush(
+        {"My-Stream.X": [{"id": "a1"}]}, extra_config={"table_name_prefix": "px_"}
+    )
+    assert _sql(client).startswith("DELETE FROM `p`.`d`.`px_my_stream_x`")
+
+
+def test_flush_skips_empty_record_lists():
+    t, client = _run_flush({"Accounts": []})
+    client.query.assert_not_called()
     assert t._delete_buffer == {}

--- a/target_bigquery/tests/test_utils.py
+++ b/target_bigquery/tests/test_utils.py
@@ -4,6 +4,8 @@ import pytest
 import singer_sdk.typing as th
 from google.cloud.bigquery import SchemaField
 
+from unittest.mock import MagicMock, patch, call
+
 from target_bigquery.core import SchemaTranslator, bigquery_type, transform_column_name, BigQueryTable, IngestionStrategy
 from target_bigquery.proto_gen import proto_schema_factory_v2
 
@@ -701,3 +703,43 @@ def test_jit_compile_proto():
         == b"\x08\x01\x12\x04test\x19\x00\x00\x00\x00\x00\x00\xf0?"
         b" \x01*\n2020-01-012\n2020-01-01:\x0800:00:00"
     )
+
+
+# --------------------------------------------------------------------------- #
+# delete-sync (DELETERECORD)                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def _bare_target(config=None, buffer=None):
+    """A TargetBigQuery without __init__ (no worker pool / no BQ client)."""
+    from target_bigquery.target import TargetBigQuery
+
+    t = TargetBigQuery.__new__(TargetBigQuery)
+    t._delete_buffer = {} if buffer is None else buffer
+    t._config = config or {"project": "p", "dataset": "d"}
+    t._credentials = MagicMock()
+    return t
+
+
+def test_process_unknown_message_buffers_deleterecord():
+    t = _bare_target()
+    t._process_unknown_message(
+        {"type": "DELETERECORD", "stream": "Accounts", "record": {"id": "a1"}}
+    )
+    t._process_unknown_message(
+        {"type": "DELETERECORD", "stream": "Accounts", "record": {"id": "a2"}}
+    )
+    t._process_unknown_message(
+        {"type": "DELETERECORD", "stream": "Contacts", "record": {"id": "c1"}}
+    )
+    assert t._delete_buffer == {
+        "Accounts": [{"id": "a1"}, {"id": "a2"}],
+        "Contacts": [{"id": "c1"}],
+    }
+
+
+def test_process_unknown_message_raises_for_other_types():
+    t = _bare_target()
+    with pytest.raises(ValueError):
+        t._process_unknown_message({"type": "SOMETHING_ELSE"})
+    assert t._delete_buffer == {}

--- a/target_bigquery/tests/test_utils.py
+++ b/target_bigquery/tests/test_utils.py
@@ -804,6 +804,17 @@ def test_flush_denormalized_composite_pk():
     assert _vals(client) == ["1\u001f2"]
 
 
+def test_flush_chunks_by_batch_size():
+    records = [{"id": f"a{i}"} for i in range(5)]
+    _, client = _run_flush({"Accounts": records}, extra_config={"batch_size": 2})
+    assert client.query.call_count == 3  # 2 + 2 + 1
+    chunks = [
+        c.kwargs["job_config"].query_parameters[0].values
+        for c in client.query.call_args_list
+    ]
+    assert chunks == [["a0", "a1"], ["a2", "a3"], ["a4"]]
+
+
 def test_flush_skips_missing_table_and_continues():
     # NotFound (table/dataset absent) is a best-effort skip; other streams still run.
     from google.api_core.exceptions import NotFound


### PR DESCRIPTION
## Reference Ticket
- [PQ-3545](https://app.notion.com/p/peliqan/Tap-peliqan-handle-deleted-rows-37b1aa9b3879801fb668c752f58dca3e)

## Description
Adds support for the `DELETERECORD` Singer message so the BigQuery target can delete rows on demand (delete-sync).

- `DELETERECORD` messages are intercepted via a `_process_unknown_message` override (no SDK fork) and buffered per stream, then applied at end-of-pipe in `drain_all` — **after** the `clean_up()` upserts and **before** the state message — so the bookmark never advances past deletes that weren't applied.
- One parameterized `DELETE … WHERE <key> IN UNNEST(@vals)` per table, chunked by `batch_size`. Storage-mode aware: denormalized → real column (`CAST(\`col\` AS STRING)`, with `column_name_transforms` applied), FIXED → `JSON_VALUE(data, '$.col')`; composite keys are joined on the unit-separator.
- Error policy mirrors target-postgres: a key matching no row is not an error; a missing table/dataset (`NotFound`, e.g. a never-synced stream) is logged and skipped; any other failure (connection, credentials, permission, quota, bad SQL) is raised so state is not advanced.

## Companion PRs
- tap-peliqan: https://github.com/Peliqan-io/tap-peliqan/pull/137
- target-postgres: https://github.com/Peliqan-io/target-postgres/pull/28
- baserow: https://github.com/Peliqan-io/baserow/pull/5571
