### PR TITLE
[PQ-3547] [Feat]: save intermittent bookmarks (mid-run checkpoints)

### DIFF
--- a/target_bigquery/core.py
+++ b/target_bigquery/core.py
@@ -318,6 +318,8 @@ class BaseBigQuerySink(BatchSink):
             "schema_resolver_version": SchemaResolverVersion(self.config.get("schema_resolver_version", 2)),
         }
         self.table = BigQueryTable(name=self.table_name, **opts)
+        self._staging_opts = opts
+        self._staging_seq = 0
         self.create_target(key_properties=key_properties)
         self.update_schema()
         self.merge_target: Optional[BigQueryTable] = None
@@ -331,40 +333,10 @@ class BaseBigQuerySink(BatchSink):
             and self._is_upsert_candidate()
         ):
             self.merge_target = copy(self.table)
-            self.table = BigQueryTable(name=f"{self.table_name}__{int(time.time())}", **opts)
-            self.table.create_table(
-                self.client,
-                self.apply_transforms,
-                **{
-                    "table": {
-                        "expires": datetime.datetime.now() + datetime.timedelta(days=1),
-                    },
-                    "dataset": {
-                        "location": self.config.get(
-                            "location", BigQueryTable.default_dataset_options()["location"]
-                        )
-                    },
-                },
-            )
-            time.sleep(2.5)  # Wait for eventual consistency
+            self._new_staging_table()
         elif self._is_overwrite_candidate():
             self.overwrite_target = copy(self.table)
-            self.table = BigQueryTable(name=f"{self.table_name}__{int(time.time())}", **opts)
-            self.table.create_table(
-                self.client,
-                self.apply_transforms,
-                **{
-                    "table": {
-                        "expires": datetime.datetime.now() + datetime.timedelta(days=1),
-                    },
-                    "dataset": {
-                        "location": self.config.get(
-                            "location", BigQueryTable.default_dataset_options()["location"]
-                        )
-                    },
-                },
-            )
-            time.sleep(2.5)  # Wait for eventual consistency
+            self._new_staging_table()
 
         self.global_par_typ = target.par_typ
         self.global_queue = target.queue
@@ -512,55 +484,82 @@ class BaseBigQuerySink(BatchSink):
         """Return a worker class for the given parallelization type."""
         raise NotImplementedError
 
+    def _new_staging_table(self) -> None:
+        """Create a fresh temp staging table and point self.table at it.
+
+        Used at init (first staging table) and by checkpoint() to rotate a new
+        temp in after each mid-run MERGE, so subsequent records for this stream
+        keep staging safely. A monotonic seq avoids same-second name clashes."""
+        self._staging_seq += 1
+        name = f"{self.table_name}__{int(time.time())}_{self._staging_seq}"
+        self.table = BigQueryTable(name=name, **self._staging_opts)
+        self.table.create_table(
+            self.client,
+            self.apply_transforms,
+            **{
+                "table": {"expires": datetime.datetime.now() + datetime.timedelta(days=1)},
+                "dataset": {
+                    "location": self.config.get(
+                        "location", BigQueryTable.default_dataset_options()["location"]
+                    )
+                },
+            },
+        )
+        time.sleep(2.5)  # Wait for eventual consistency
+
+    def _merge_staging_into_target(self) -> None:
+        """Dedupe + MERGE the current temp table into merge_target. Raises on
+        failure — never drops the temp, never swallows (PQ-3547: a failed MERGE
+        must not advance the bookmark or silently lose the staged batch)."""
+        target = self.merge_target.as_table()
+        date_columns = ["_sdc_extracted_at", "_sdc_received_at"]
+        tmp, ctas_tmp = None, "SELECT 1 AS _no_op"
+        if self._is_dedupe_before_upsert_candidate():
+            # We can't use MERGE with a non-unique key, so we need to dedupe the temp table into
+            # a _SESSION scoped intermediate table.
+            tmp = f"{self.merge_target.name}__tmp"
+            dedupe_query = (
+                f"SELECT * FROM {self.table.get_escaped_name()} "
+                f"QUALIFY ROW_NUMBER() OVER (PARTITION BY {', '.join(self.key_properties)} "
+                f"ORDER BY COALESCE({', '.join(date_columns)}) DESC) = 1"
+            )
+            ctas_tmp = f"CREATE OR REPLACE TEMP TABLE `{tmp}` AS {dedupe_query}"
+        merge_clause = (
+            f"MERGE `{self.merge_target}` AS target USING `{tmp or self.table}` AS source ON "
+            + " AND ".join(f"target.`{f}` = source.`{f}`" for f in self.key_properties)
+        )
+        update_clause = "UPDATE SET " + ", ".join(
+            f"target.`{f.name}` = source.`{f.name}`" for f in target.schema
+        )
+        insert_clause = (
+            f"INSERT ({', '.join(f'`{f.name}`' for f in target.schema)}) "
+            f"VALUES ({', '.join(f'source.`{f.name}`' for f in target.schema)})"
+        )
+        merge_sql = (
+            f"{ctas_tmp}; {merge_clause} "
+            f"WHEN MATCHED THEN {update_clause} "
+            f"WHEN NOT MATCHED THEN {insert_clause}; "
+            f"DROP TABLE IF EXISTS {self.table.get_escaped_name()};"
+        )
+        self.client.query(merge_sql).result()
+
+    def checkpoint(self) -> None:
+        """Mid-run: MERGE staged rows into the real table and rotate a fresh
+        temp. Repeatable and non-destructive (merge_target is preserved).
+        No-op unless this is a merge/upsert stream. Callers must have run the
+        per-method durability barrier first (workers joined, appends resolved,
+        fallback jobs awaited)."""
+        if self.merge_target is None:
+            return
+        self._merge_staging_into_target()
+        self._new_staging_table()
+
     def clean_up(self) -> None:
-        """Clean up the target table."""
+        """Finalize at end-of-pipe: MERGE (or overwrite) staging into target,
+        then tear down. Unlike checkpoint(), this is the terminal step."""
         if self.merge_target is not None:
             # We must merge the temp table into the target table.
-            target = self.merge_target.as_table()
-            date_columns = ["_sdc_extracted_at", "_sdc_received_at"]
-            tmp, ctas_tmp = None, "SELECT 1 AS _no_op"
-            if self._is_dedupe_before_upsert_candidate():
-                # We can't use MERGE with a non-unique key, so we need to dedupe the temp table into
-                # a _SESSION scoped intermediate table.
-                tmp = f"{self.merge_target.name}__tmp"
-                dedupe_query = (
-                    f"SELECT * FROM {self.table.get_escaped_name()} "
-                    f"QUALIFY ROW_NUMBER() OVER (PARTITION BY {', '.join(self.key_properties)} "
-                    f"ORDER BY COALESCE({', '.join(date_columns)}) DESC) = 1"
-                )
-                ctas_tmp = f"CREATE OR REPLACE TEMP TABLE `{tmp}` AS {dedupe_query}"
-            merge_clause = (
-                f"MERGE `{self.merge_target}` AS target USING `{tmp or self.table}` AS source ON "
-                + " AND ".join(f"target.`{f}` = source.`{f}`" for f in self.key_properties)
-            )
-            update_clause = "UPDATE SET " + ", ".join(
-                f"target.`{f.name}` = source.`{f.name}`" for f in target.schema
-            )
-            insert_clause = (
-                f"INSERT ({', '.join(f'`{f.name}`' for f in target.schema)}) "
-                f"VALUES ({', '.join(f'source.`{f.name}`' for f in target.schema)})"
-            )
-            merge_sql = (
-                f"{ctas_tmp}; {merge_clause} "
-                f"WHEN MATCHED THEN {update_clause} "
-                f"WHEN NOT MATCHED THEN {insert_clause}; "
-                f"DROP TABLE IF EXISTS {self.table.get_escaped_name()};"
-            )
-            try:
-                self.client.query(merge_sql).result()
-            except Exception as exc:
-                self.logger.warning(
-                    "Merge failed for stream '%s', falling back to DROP of temp table '%s'. Error: %s",
-                    self.stream_name,
-                    self.table,
-                    exc,
-                )
-                try:
-                    self.client.query(
-                        f"DROP TABLE IF EXISTS {self.table.get_escaped_name()};"
-                    ).result()
-                except Exception:
-                    pass
+            self._merge_staging_into_target()
             self.table = self.merge_target
             self.merge_target = None
         elif self.overwrite_target is not None:

--- a/target_bigquery/storage_write.py
+++ b/target_bigquery/storage_write.py
@@ -748,6 +748,15 @@ class BigQueryStorageWriteSink(BaseBigQuerySink):
         self.commit_streams()
         self._wait_for_fallback_jobs()
 
+    def checkpoint(self) -> None:
+        # Durability barrier before the mid-run MERGE: commit any application
+        # streams (no-op for _default) and await oversized-row fallback Load
+        # Jobs, so every staged row is in the temp before we merge. Mirrors
+        # clean_up() above, but for the non-terminal, repeatable checkpoint.
+        self.commit_streams()
+        self._wait_for_fallback_jobs()
+        super().checkpoint()
+
 
 def _stringify_json_columns(record: Dict[str, Any], fields: List[Any]) -> Dict[str, Any]:
     """Serialize values bound for BigQuery JSON columns to strings, recursively.

--- a/target_bigquery/storage_write.py
+++ b/target_bigquery/storage_write.py
@@ -591,12 +591,24 @@ class BigQueryStorageWriteSink(BaseBigQuerySink):
         self._fallback_rows = 0
         self._fallback_jobs: List[bigquery.LoadJob] = []
         self.open_streams: Set[Tuple[str, writer.AppendRowsStream]] = set()
+        self.stream_notification, self.stream_notifier = target.pipe_cls(False)
+        self._refresh_write_destination()
+
+    def _refresh_write_destination(self) -> None:
+        """(Re)compute the write destination from the CURRENT `self.table`.
+
+        `self.parent` and `self.template` (its embedded `write_stream`) both
+        encode the staging table generation. `BaseBigQuerySink.checkpoint()`
+        rotates `self.table` to a fresh staging table after a successful
+        MERGE, but does not know about these storage_write-specific
+        attributes — so this must be called both at __init__ time and again
+        immediately after every successful rotation (PQ-3547 C1), otherwise
+        already-queued/future Jobs keep targeting the dropped old generation."""
         self.parent = BigQueryWriteClient.table_path(
             self.table.project,
             self.table.dataset,
             self.table.name,
         )
-        self.stream_notification, self.stream_notifier = target.pipe_cls(False)
         self.template = generate_template(self.proto_schema)
 
     @property
@@ -756,6 +768,13 @@ class BigQueryStorageWriteSink(BaseBigQuerySink):
         self.commit_streams()
         self._wait_for_fallback_jobs()
         super().checkpoint()
+        # super().checkpoint() rotated self.table to a fresh staging table
+        # (PQ-3547 C1) — if it raised, we don't get here, and no rotation
+        # happened, so the old parent/template are still correct and must be
+        # left alone. On success, recompute parent/template from the NEW
+        # self.table so the next queued Job (and any post-rotation stream
+        # open) targets generation N+1, never the just-dropped generation N.
+        self._refresh_write_destination()
 
 
 def _stringify_json_columns(record: Dict[str, Any], fields: List[Any]) -> Dict[str, Any]:

--- a/target_bigquery/target.py
+++ b/target_bigquery/target.py
@@ -614,6 +614,28 @@ class TargetBigQuery(Target):
         ):
             self.drain_all(is_endofpipe=False)
 
+    def _shutdown_workers(self) -> None:
+        """Tear down the worker PROCESSES only -- never touches sinks or state.
+
+        This is the process-teardown half of the old drain_all(is_endofpipe=True)
+        body, extracted so the error path in drain_one() can stop workers WITHOUT
+        going through the sink clean_up() / checkpoint() / _flush_deletes() /
+        _write_state_message() machinery. Emitting a STATE message after a worker
+        reported a load failure would advance the bookmark past a failed batch and
+        silently drop data (PQ-3547 P0).
+
+        Uses a stable snapshot of self.workers and is safe on an empty list. This
+        also fixes the old inline join loop
+        (`while len(self.workers): worker.join(); worker = self.workers.pop()`),
+        which double-joined the last worker and skipped the first."""
+        workers = list(self.workers)
+        for worker in workers:
+            if worker.is_alive():
+                self.queue.put(None)
+        for worker in workers:
+            worker.join()
+        self.workers.clear()
+
     def drain_one(self, sink: Sink) -> None:  # type: ignore
         """Drain a sink. Includes a hook to manage the worker pool and notifications."""
         #self.logger.info(f"Jobs queued : {self.queue.qsize()} | Max nb jobs queued : {os.cpu_count() * 4} | Nb workers : {len(self.workers)} | Max nb workers : {os.cpu_count() * 2}")
@@ -629,16 +651,16 @@ class TargetBigQuery(Target):
             e, msg = self.error_notification.recv()
             if self.config.get("fail_fast", True):
                 self.logger.error(msg)
+                # Tear down worker PROCESSES only and re-raise. We must NOT call
+                # drain_all() here: that path runs sink.clean_up()/checkpoint(),
+                # _flush_deletes() and _write_state_message(), which would emit a
+                # STATE message advancing the bookmark past the failed batch and
+                # silently drop data on resume (PQ-3547 P0). Preserve the original
+                # error even if teardown itself fails -- no fallback may emit STATE.
                 try:
-                    # Try to drain if we can. This is a best effort.
-                    # TODO: we should consider if draining here is the right thing
-                    # to do. It's _possible_ we increment the state message when
-                    # data is not actually written. Its _unlikely_ so the upside is
-                    # greater than the downside for now but will revisit this.
-                    self.logger.error("Draining all sinks and terminating.")
-                    self.drain_all(is_endofpipe=True)
+                    self._shutdown_workers()
                 except Exception:
-                    self.logger.error("Drain failed.")
+                    self.logger.error("Worker shutdown after error failed.")
                 raise RuntimeError(msg) from e
         super().drain_one(sink)
 
@@ -659,12 +681,11 @@ class TargetBigQuery(Target):
         sink: BaseBigQuerySink
         self._drain_all(list(self._sinks_active.values()), self.max_parallelism)
         if is_endofpipe:
-            for worker in self.workers:
-                if worker.is_alive():
-                    self.queue.put(None)
-            while len(self.workers):
-                worker.join()
-                worker = self.workers.pop()
+            # Tear down worker processes via the shared helper (fixes the old
+            # double-join/skip-first bug), THEN finalize sinks. Order preserved:
+            # shutdown -> raise pending worker error -> clean_up() -> _flush_deletes
+            # -> _write_state_message (the last three below, outside this branch).
+            self._shutdown_workers()
             self._raise_pending_worker_error()
             for sink in self._sinks_active.values():
                 sink.clean_up()
@@ -672,18 +693,24 @@ class TargetBigQuery(Target):
             for worker in self.workers:
                 worker.join()
             self._raise_pending_worker_error()
-            # Per-sink scope gate (PQ-3547 §5.3/§10). This branch also runs on
-            # the singer-sdk max-age timer (_handle_max_record_age ->
-            # drain_all(is_endofpipe=False)), which bypasses the
-            # _process_state_message trigger. Only checkpoint (MERGE) sinks that
-            # are genuinely in scope; every out-of-scope sink
-            # (gcs_stage/streaming_insert/overwrite) keeps its origin/master
-            # pre_state_hook() behavior, so a mid-run drain never MERGEs an
-            # empty staging table and advances the bookmark past data that is
-            # only durable at clean_up(). Fail-fast: no try/except -- the first
-            # checkpoint() error propagates before the counter reset and STATE.
+            # Run-level overwrite exclusion (PQ-3547 §5.3/§10, P2). This branch
+            # also runs on the singer-sdk max-age timer (_handle_max_record_age
+            # -> drain_all(is_endofpipe=False)), which bypasses the
+            # _process_state_message trigger. The rule is run-level: if ANY active
+            # sink is in overwrite mode, NO sink is checkpointed on the mid-run
+            # drain -- every sink keeps its origin/master pre_state_hook()
+            # behavior. Per-sink gating alone would wrongly MERGE an upsert sink
+            # that coexists with an overwrite sink. With no overwrite target
+            # present, fall back to the finer-grained per-sink eligibility gate so
+            # out-of-scope sinks (gcs_stage/streaming_insert) still use
+            # pre_state_hook(). Fail-fast: no try/except -- the first checkpoint()
+            # error propagates before the counter reset and STATE.
+            has_overwrite = any(
+                getattr(sink, "overwrite_target", None) is not None
+                for sink in self._sinks_active.values()
+            )
             for sink in self._sinks_active.values():
-                if self._sink_checkpoint_eligible(sink):
+                if not has_overwrite and self._sink_checkpoint_eligible(sink):
                     sink.checkpoint()
                 else:
                     sink.pre_state_hook()

--- a/target_bigquery/target.py
+++ b/target_bigquery/target.py
@@ -56,10 +56,6 @@ WORKER_CREATION_MIN_INTERVAL = 5
 """Minimum time between worker creation attempts."""
 
 
-class CheckpointError(Exception):
-    """One or more streams failed to MERGE; their bookmarks were held back."""
-
-
 class TargetBigQuery(Target):
     """Target for BigQuery."""
 
@@ -395,11 +391,6 @@ class TargetBigQuery(Target):
         # threshold triggers a non-endofpipe drain_all() (MERGE + emit state).
         self._checkpoint_row_threshold = int(self.config.get("checkpoint_row_threshold", 10_000))
         self._records_since_checkpoint = 0
-        # Per-stream checkpoint failure isolation (PQ-3547): the last state we
-        # successfully wrote (so a failed stream's bookmark can be rolled back
-        # to it), and the set of streams that failed to MERGE this run.
-        self._last_committed_state: dict = {"bookmarks": {}}
-        self._checkpoint_failures: set = set()
 
     def increment_jobs_enqueued(self) -> None:
         """Increment the number of jobs enqueued."""
@@ -560,6 +551,27 @@ class TargetBigQuery(Target):
         super()._process_record_message(message_dict)
         self._records_since_checkpoint += 1
 
+    def _row_threshold_checkpoint_eligible(self) -> bool:
+        """Whether this run is in scope for PQ-3547 row-threshold mid-run
+        checkpoints (MERGE + STATE at a category boundary).
+
+        Only `batch_job` and `storage_write_api` support the non-destructive
+        checkpoint()/MERGE path this feature relies on, and only when at
+        least one active sink is actually upserting (`merge_target is not
+        None`). `gcs_stage` and `streaming_insert` must keep their
+        origin/master behavior, as must overwrite-mode sinks (which DROP +
+        recreate the target table rather than MERGE into it) -- a mid-run
+        checkpoint of an overwrite sink would truncate/replace the real table
+        before end-of-pipe, which is not this feature's contract.
+        """
+        method = self.config.get("method", "storage_write_api")
+        if method not in ("batch_job", "storage_write_api"):
+            return False
+        sinks = list(self._sinks_active.values())
+        if any(getattr(sink, "overwrite_target", None) is not None for sink in sinks):
+            return False
+        return any(getattr(sink, "merge_target", None) is not None for sink in sinks)
+
     def _process_state_message(self, message_dict: dict) -> None:
         """Process a STATE message (category/stream boundary), then checkpoint
         mid-run if enough records have accrued since the last checkpoint.
@@ -572,6 +584,7 @@ class TargetBigQuery(Target):
         if (
             self._checkpoint_row_threshold >= 0
             and self._records_since_checkpoint >= self._checkpoint_row_threshold
+            and self._row_threshold_checkpoint_eligible()
         ):
             self.drain_all(is_endofpipe=False)
 
@@ -605,7 +618,17 @@ class TargetBigQuery(Target):
 
     def drain_all(self, is_endofpipe: bool = False) -> None:  # type: ignore
         """Drain all sinks and write state message. If is_endofpipe, execute clean_up() on all sinks.
-        Includes an additional hook to allow sinks to do any pre-state message processing."""
+
+        Fail-fast checkpoint finalization (PQ-3547): sinks are finalized
+        (checkpoint() mid-run / clean_up() at end-of-pipe) in a plain loop
+        with no per-sink exception handling. The first failure propagates
+        immediately, before `_flush_deletes()` and before
+        `_write_state_message()` run, so a failed checkpoint/clean_up emits
+        no STATE for that boundary and the process exits non-zero. Earlier
+        sinks that already finalized successfully in the same loop are not
+        rolled back -- their data is durable and safe to replay (upsert +
+        dedupe), but no new STATE reflects them until a later run succeeds.
+        """
         state = copy.deepcopy(self._latest_state)
         sink: BaseBigQuerySink
         self._drain_all(list(self._sinks_active.values()), self.max_parallelism)
@@ -617,12 +640,14 @@ class TargetBigQuery(Target):
                 worker.join()
                 worker = self.workers.pop()
             self._raise_pending_worker_error()
-            self._run_sink_finalizers(state, endofpipe=True)
+            for sink in self._sinks_active.values():
+                sink.clean_up()
         else:
             for worker in self.workers:
                 worker.join()
             self._raise_pending_worker_error()
-            self._run_sink_finalizers(state, endofpipe=False)
+            for sink in self._sinks_active.values():
+                sink.checkpoint()
             self._records_since_checkpoint = 0
         # Apply buffered DELETERECORDs *before* advancing state, so the bookmark
         # never moves past deletes that were not applied. At end-of-pipe this runs
@@ -633,42 +658,7 @@ class TargetBigQuery(Target):
             self._flush_deletes()
         if state:
             self._write_state_message(state)
-            self._last_committed_state = copy.deepcopy(state)
         self._reset_max_record_age()
-        if is_endofpipe and self._checkpoint_failures:
-            raise CheckpointError(
-                "streams failed to merge, bookmarks held back: "
-                f"{sorted(self._checkpoint_failures)}"
-            )
-
-    def _run_sink_finalizers(self, state: dict, endofpipe: bool) -> None:
-        """Checkpoint (mid-run) or clean_up (end-of-pipe) each active sink,
-        isolating failures per-stream (PQ-3547).
-
-        A failed stream's bookmark subtree in `state["bookmarks"]` is rolled
-        back to its last successfully-committed value (or dropped if it was
-        never committed), so that stream is retried from its last-known-good
-        position on the next run. Other streams still advance. Never drops
-        data, never fails silently -- the failure is recorded in
-        `self._checkpoint_failures` and logged; `drain_all` raises
-        `CheckpointError` at end-of-pipe if any stream failed."""
-        for sink in self._sinks_active.values():
-            try:
-                sink.clean_up() if endofpipe else sink.checkpoint()
-            except Exception as exc:  # noqa: BLE001 - isolate one stream's failure
-                name = sink.stream_name
-                self._checkpoint_failures.add(name)
-                self.logger.error(
-                    "Checkpoint failed for stream '%s'; holding its bookmark. %s",
-                    name,
-                    exc,
-                )
-                bookmarks = state.setdefault("bookmarks", {})
-                last_bookmarks = self._last_committed_state.get("bookmarks", {})
-                if name in last_bookmarks:
-                    bookmarks[name] = copy.deepcopy(last_bookmarks[name])
-                else:
-                    bookmarks.pop(name, None)
 
     def _raise_pending_worker_error(self) -> None:
         """Surface worker errors that arrived after the last drain_one poll.

--- a/target_bigquery/target.py
+++ b/target_bigquery/target.py
@@ -614,7 +614,8 @@ class TargetBigQuery(Target):
                 worker.join()
             self._raise_pending_worker_error()
             for sink in self._sinks_active.values():
-                sink.pre_state_hook()
+                sink.checkpoint()
+            self._records_since_checkpoint = 0
         # Apply buffered DELETERECORDs *before* advancing state, so the bookmark
         # never moves past deletes that were not applied. At end-of-pipe this runs
         # after the clean_up() upserts above (an upsert + delete of the same key in

--- a/target_bigquery/target.py
+++ b/target_bigquery/target.py
@@ -551,21 +551,47 @@ class TargetBigQuery(Target):
         super()._process_record_message(message_dict)
         self._records_since_checkpoint += 1
 
+    def _method_supports_checkpoint(self) -> bool:
+        """Whether the configured target method supports the non-destructive
+        checkpoint()/MERGE path PQ-3547 relies on. Only `batch_job` and
+        `storage_write_api` do; `gcs_stage` and `streaming_insert` keep their
+        origin/master mid-run behavior. The default method is
+        `storage_write_api`."""
+        return self.config.get("method", "storage_write_api") in (
+            "batch_job",
+            "storage_write_api",
+        )
+
+    def _sink_checkpoint_eligible(self, sink: "BaseBigQuerySink") -> bool:
+        """Whether an individual active sink may be checkpointed (MERGE) on a
+        mid-run drain. Eligible only when the method supports checkpointing AND
+        the sink is upserting (`merge_target is not None`) AND it is not an
+        overwrite sink (`overwrite_target is None`). An overwrite sink DROPs +
+        recreates the real table, and mid-run that would truncate/replace it
+        before end-of-pipe -- not this feature's contract.
+
+        Used per sink in drain_all()'s non-endofpipe branch: this is the gate
+        that also covers the singer-sdk max-age drain, which calls
+        drain_all(is_endofpipe=False) directly and bypasses the
+        _process_state_message trigger below."""
+        return (
+            self._method_supports_checkpoint()
+            and getattr(sink, "merge_target", None) is not None
+            and getattr(sink, "overwrite_target", None) is None
+        )
+
     def _row_threshold_checkpoint_eligible(self) -> bool:
         """Whether this run is in scope for PQ-3547 row-threshold mid-run
         checkpoints (MERGE + STATE at a category boundary).
 
-        Only `batch_job` and `storage_write_api` support the non-destructive
-        checkpoint()/MERGE path this feature relies on, and only when at
-        least one active sink is actually upserting (`merge_target is not
-        None`). `gcs_stage` and `streaming_insert` must keep their
-        origin/master behavior, as must overwrite-mode sinks (which DROP +
-        recreate the target table rather than MERGE into it) -- a mid-run
-        checkpoint of an overwrite sink would truncate/replace the real table
-        before end-of-pipe, which is not this feature's contract.
-        """
-        method = self.config.get("method", "storage_write_api")
-        if method not in ("batch_job", "storage_write_api"):
+        Requires the method to support checkpointing and at least one active
+        sink to be actually upserting (`merge_target is not None`). If ANY
+        active sink is in overwrite mode the whole run stays out of scope
+        (origin/master behavior) -- §5.3 trigger condition "no active sink is
+        in overwrite mode". The per-sink drain_all gate
+        (_sink_checkpoint_eligible) is finer-grained; this run-level gate only
+        decides whether the row-threshold trigger fires at all."""
+        if not self._method_supports_checkpoint():
             return False
         sinks = list(self._sinks_active.values())
         if any(getattr(sink, "overwrite_target", None) is not None for sink in sinks):
@@ -646,8 +672,21 @@ class TargetBigQuery(Target):
             for worker in self.workers:
                 worker.join()
             self._raise_pending_worker_error()
+            # Per-sink scope gate (PQ-3547 §5.3/§10). This branch also runs on
+            # the singer-sdk max-age timer (_handle_max_record_age ->
+            # drain_all(is_endofpipe=False)), which bypasses the
+            # _process_state_message trigger. Only checkpoint (MERGE) sinks that
+            # are genuinely in scope; every out-of-scope sink
+            # (gcs_stage/streaming_insert/overwrite) keeps its origin/master
+            # pre_state_hook() behavior, so a mid-run drain never MERGEs an
+            # empty staging table and advances the bookmark past data that is
+            # only durable at clean_up(). Fail-fast: no try/except -- the first
+            # checkpoint() error propagates before the counter reset and STATE.
             for sink in self._sinks_active.values():
-                sink.checkpoint()
+                if self._sink_checkpoint_eligible(sink):
+                    sink.checkpoint()
+                else:
+                    sink.pre_state_hook()
             self._records_since_checkpoint = 0
         # Apply buffered DELETERECORDs *before* advancing state, so the bookmark
         # never moves past deletes that were not applied. At end-of-pipe this runs

--- a/target_bigquery/target.py
+++ b/target_bigquery/target.py
@@ -55,6 +55,11 @@ WORKER_CAPACITY_FACTOR = 5
 WORKER_CREATION_MIN_INTERVAL = 5
 """Minimum time between worker creation attempts."""
 
+
+class CheckpointError(Exception):
+    """One or more streams failed to MERGE; their bookmarks were held back."""
+
+
 class TargetBigQuery(Target):
     """Target for BigQuery."""
 
@@ -390,6 +395,11 @@ class TargetBigQuery(Target):
         # threshold triggers a non-endofpipe drain_all() (MERGE + emit state).
         self._checkpoint_row_threshold = int(self.config.get("checkpoint_row_threshold", 10_000))
         self._records_since_checkpoint = 0
+        # Per-stream checkpoint failure isolation (PQ-3547): the last state we
+        # successfully wrote (so a failed stream's bookmark can be rolled back
+        # to it), and the set of streams that failed to MERGE this run.
+        self._last_committed_state: dict = {"bookmarks": {}}
+        self._checkpoint_failures: set = set()
 
     def increment_jobs_enqueued(self) -> None:
         """Increment the number of jobs enqueued."""
@@ -607,14 +617,12 @@ class TargetBigQuery(Target):
                 worker.join()
                 worker = self.workers.pop()
             self._raise_pending_worker_error()
-            for sink in self._sinks_active.values():
-                sink.clean_up()
+            self._run_sink_finalizers(state, endofpipe=True)
         else:
             for worker in self.workers:
                 worker.join()
             self._raise_pending_worker_error()
-            for sink in self._sinks_active.values():
-                sink.checkpoint()
+            self._run_sink_finalizers(state, endofpipe=False)
             self._records_since_checkpoint = 0
         # Apply buffered DELETERECORDs *before* advancing state, so the bookmark
         # never moves past deletes that were not applied. At end-of-pipe this runs
@@ -625,7 +633,42 @@ class TargetBigQuery(Target):
             self._flush_deletes()
         if state:
             self._write_state_message(state)
+            self._last_committed_state = copy.deepcopy(state)
         self._reset_max_record_age()
+        if is_endofpipe and self._checkpoint_failures:
+            raise CheckpointError(
+                "streams failed to merge, bookmarks held back: "
+                f"{sorted(self._checkpoint_failures)}"
+            )
+
+    def _run_sink_finalizers(self, state: dict, endofpipe: bool) -> None:
+        """Checkpoint (mid-run) or clean_up (end-of-pipe) each active sink,
+        isolating failures per-stream (PQ-3547).
+
+        A failed stream's bookmark subtree in `state["bookmarks"]` is rolled
+        back to its last successfully-committed value (or dropped if it was
+        never committed), so that stream is retried from its last-known-good
+        position on the next run. Other streams still advance. Never drops
+        data, never fails silently -- the failure is recorded in
+        `self._checkpoint_failures` and logged; `drain_all` raises
+        `CheckpointError` at end-of-pipe if any stream failed."""
+        for sink in self._sinks_active.values():
+            try:
+                sink.clean_up() if endofpipe else sink.checkpoint()
+            except Exception as exc:  # noqa: BLE001 - isolate one stream's failure
+                name = sink.stream_name
+                self._checkpoint_failures.add(name)
+                self.logger.error(
+                    "Checkpoint failed for stream '%s'; holding its bookmark. %s",
+                    name,
+                    exc,
+                )
+                bookmarks = state.setdefault("bookmarks", {})
+                last_bookmarks = self._last_committed_state.get("bookmarks", {})
+                if name in last_bookmarks:
+                    bookmarks[name] = copy.deepcopy(last_bookmarks[name])
+                else:
+                    bookmarks.pop(name, None)
 
     def _raise_pending_worker_error(self) -> None:
         """Surface worker errors that arrived after the last drain_one poll.

--- a/target_bigquery/target.py
+++ b/target_bigquery/target.py
@@ -330,6 +330,18 @@ class TargetBigQuery(Target):
             ),
             allowed_values=[1, 2],
         ),
+        th.Property(
+            "checkpoint_row_threshold",
+            th.IntegerType,
+            default=10_000,
+            description=(
+                "The number of records to process (across all streams) before triggering a mid-run"
+                " checkpoint (MERGE staged rows into the target table and emit a STATE message) at"
+                " the next category/stream boundary. Only applies to merge/upsert streams. A value"
+                " of 0 checkpoints at every category boundary; a very large value effectively"
+                " disables mid-run checkpoints (only end-of-pipe finalizes)."
+            ),
+        ),
     ).to_dict()
 
     def __init__(self, *args, **kwargs) -> None:
@@ -373,6 +385,11 @@ class TargetBigQuery(Target):
         self.worker_pings: Dict[str, float] = {}
         self._jobs_enqueued = 0
         self._last_worker_creation = 0.0
+        # Mid-run checkpoint trigger (PQ-3547): count records across all
+        # streams since the last checkpoint; a STATE message at or past the
+        # threshold triggers a non-endofpipe drain_all() (MERGE + emit state).
+        self._checkpoint_row_threshold = int(self.config.get("checkpoint_row_threshold", 10_000))
+        self._records_since_checkpoint = 0
 
     def increment_jobs_enqueued(self) -> None:
         """Increment the number of jobs enqueued."""
@@ -527,6 +544,26 @@ class TargetBigQuery(Target):
             self._delete_buffer.setdefault(stream, []).append(record)
             return
         super()._process_unknown_message(message_dict)
+
+    def _process_record_message(self, message_dict: dict) -> None:
+        """Process a RECORD message, then tally it toward the checkpoint window."""
+        super()._process_record_message(message_dict)
+        self._records_since_checkpoint += 1
+
+    def _process_state_message(self, message_dict: dict) -> None:
+        """Process a STATE message (category/stream boundary), then checkpoint
+        mid-run if enough records have accrued since the last checkpoint.
+
+        threshold == 0 means every category boundary checkpoints (counter is
+        always >= 0). A very large threshold effectively disables mid-run
+        checkpoints (only max-age and end-of-pipe still finalize).
+        """
+        super()._process_state_message(message_dict)
+        if (
+            self._checkpoint_row_threshold >= 0
+            and self._records_since_checkpoint >= self._checkpoint_row_threshold
+        ):
+            self.drain_all(is_endofpipe=False)
 
     def drain_one(self, sink: Sink) -> None:  # type: ignore
         """Drain a sink. Includes a hook to manage the worker pool and notifications."""

--- a/target_bigquery/tests/test_utils.py
+++ b/target_bigquery/tests/test_utils.py
@@ -982,7 +982,8 @@ def test_checkpoint_noop_when_no_merge_target(monkeypatch):
 # --------------------------------------------------------------------------- #
 def test_storage_write_checkpoint_barrier_before_merge(monkeypatch):
     """storage_write must commit streams + await fallback Load Jobs BEFORE the
-    MERGE runs (order matters: rows must be durable in the temp first)."""
+    MERGE runs (order matters: rows must be durable in the temp first), and
+    must refresh parent/template only AFTER the MERGE (rotation) succeeds."""
     from target_bigquery.storage_write import BigQueryStorageWriteDenormalizedSink as SW
     import target_bigquery.core as core
 
@@ -992,13 +993,131 @@ def test_storage_write_checkpoint_barrier_before_merge(monkeypatch):
     calls = []
     s.commit_streams = lambda: calls.append("commit")
     s._wait_for_fallback_jobs = lambda: calls.append("fallback")
+    s._refresh_write_destination = lambda: calls.append("refresh")
     # Base checkpoint() (Task 1) records "merge"; patched via monkeypatch so
     # it's restored automatically even if the assertion below fails.
     monkeypatch.setattr(core.BaseBigQuerySink, "checkpoint", lambda self: calls.append("merge"))
 
     SW.checkpoint(s)
 
-    assert calls == ["commit", "fallback", "merge"]
+    assert calls == ["commit", "fallback", "merge", "refresh"]
+
+
+# --------------------------------------------------------------------------- #
+# _refresh_write_destination() — generation rotation (PQ-3547 C1)              #
+# --------------------------------------------------------------------------- #
+def _sw_sink():
+    """A BigQueryStorageWriteDenormalizedSink-like object with no BQ/network
+    dependency, built the same way as `_merge_sink()` but with the storage_write
+    write-destination attributes (`parent`/`template`) initialized via
+    `_refresh_write_destination()`, mirroring what `__init__` now does."""
+    from target_bigquery.storage_write import BigQueryStorageWriteDenormalizedSink as SW
+    from target_bigquery.core import BigQueryTable, IngestionStrategy
+    from target_bigquery.proto_gen import proto_schema_factory_v2
+
+    s = SW.__new__(SW)
+    s.client = MagicMock()
+    s.stream_name = "SalesInvoiceLines"
+    s._key_properties = ["id"]  # key_properties is a read-only property in the SDK base
+    s._config = {"project": "p", "dataset": "d"}  # config is also a read-only property
+    opts = {
+        "project": "p", "dataset": "d", "jsonschema": {"properties": {}},
+        "transforms": {}, "ingestion_strategy": IngestionStrategy.DENORMALIZED,
+    }
+    s._staging_opts = opts
+    s._staging_seq = 0
+    real = BigQueryTable(name="salesinvoicelines", **opts)
+    s.merge_target = _copy(real)
+    s.table = BigQueryTable(name="salesinvoicelines__gen1_1", **opts)
+    # Bypass the real schema-translation path (irrelevant to rotation logic);
+    # a real proto message class is still used so generate_template's
+    # descriptor-embedding logic runs unmocked.
+    s._proto_schema = proto_schema_factory_v2([])
+    s.open_streams = set()
+    s._refresh_write_destination()  # what __init__ now does
+    return s
+
+
+def test_refresh_write_destination_parent_matches_current_table():
+    from google.cloud.bigquery_storage_v1 import BigQueryWriteClient
+
+    s = _sw_sink()
+    assert s.parent == BigQueryWriteClient.table_path("p", "d", "salesinvoicelines__gen1_1")
+
+
+def test_checkpoint_rotates_parent_and_template_to_generation_two(monkeypatch):
+    """After a successful checkpoint (MERGE + staging-table rotation), `parent`
+    must reference the NEW (generation-2) table and a fresh template object
+    must have been created — never the dropped generation-1 table/template."""
+    from google.cloud.bigquery_storage_v1 import BigQueryWriteClient
+    from target_bigquery.core import BigQueryTable
+    from target_bigquery.storage_write import BigQueryStorageWriteDenormalizedSink as SW
+    import target_bigquery.core as core
+    import target_bigquery.storage_write as sw
+
+    s = _sw_sink()
+    gen1_parent, gen1_template = s.parent, s.template
+    assert gen1_parent == BigQueryWriteClient.table_path("p", "d", "salesinvoicelines__gen1_1")
+
+    s.commit_streams = lambda: None
+    s._wait_for_fallback_jobs = lambda: None
+
+    def fake_super_checkpoint(self):
+        # Mirrors what BaseBigQuerySink.checkpoint() does on a successful
+        # MERGE: rotate self.table to a fresh staging table.
+        self.table = BigQueryTable(name="salesinvoicelines__gen2_1", **self._staging_opts)
+
+    monkeypatch.setattr(core.BaseBigQuerySink, "checkpoint", fake_super_checkpoint)
+    template_calls = []
+    real_generate_template = sw.generate_template
+    monkeypatch.setattr(
+        sw, "generate_template",
+        lambda schema: (template_calls.append(schema), real_generate_template(schema))[1],
+    )
+
+    SW.checkpoint(s)
+
+    expected_gen2_parent = BigQueryWriteClient.table_path("p", "d", "salesinvoicelines__gen2_1")
+    assert s.parent == expected_gen2_parent
+    assert s.parent != gen1_parent
+    assert s.template is not gen1_template
+    assert len(template_calls) == 1  # fresh template built exactly once, post-MERGE
+
+    # A Job created after this checkpoint carries the NEW parent, never the
+    # dropped generation-1 table.
+    job = sw.Job(parent=s.parent, template=s.template, stream_notifier=None, data=None)
+    assert job.parent == expected_gen2_parent
+    assert job.parent != gen1_parent
+
+
+def test_checkpoint_does_not_refresh_destination_when_merge_raises(monkeypatch):
+    """If the MERGE (super().checkpoint()) raises, no rotation happened, so
+    parent/template must be left pointing at the still-current staging table."""
+    from target_bigquery.storage_write import BigQueryStorageWriteDenormalizedSink as SW
+    import target_bigquery.core as core
+    import target_bigquery.storage_write as sw
+
+    s = _sw_sink()
+    gen1_parent, gen1_template = s.parent, s.template
+
+    s.commit_streams = lambda: None
+    s._wait_for_fallback_jobs = lambda: None
+    monkeypatch.setattr(
+        core.BaseBigQuerySink, "checkpoint",
+        lambda self: (_ for _ in ()).throw(Exception("merge failed")),
+    )
+    refresh_calls = []
+    monkeypatch.setattr(
+        sw.BigQueryStorageWriteSink, "_refresh_write_destination",
+        lambda self: refresh_calls.append(True),
+    )
+
+    with pytest.raises(Exception, match="merge failed"):
+        SW.checkpoint(s)
+
+    assert refresh_calls == []          # never reached — merge raised first
+    assert s.parent == gen1_parent      # unchanged: still generation 1
+    assert s.template is gen1_template  # unchanged: same template object
 
 
 class _FakeSink:

--- a/target_bigquery/tests/test_utils.py
+++ b/target_bigquery/tests/test_utils.py
@@ -974,3 +974,27 @@ def test_checkpoint_noop_when_no_merge_target(monkeypatch):
                         lambda self: (_ for _ in ()).throw(AssertionError("rotated")))
     s.checkpoint()                                # must not raise / not rotate
     assert not s.client.query.called
+
+
+# --------------------------------------------------------------------------- #
+# checkpoint() barrier override for storage_write (PQ-3547)                    #
+# --------------------------------------------------------------------------- #
+def test_storage_write_checkpoint_barrier_before_merge(monkeypatch):
+    """storage_write must commit streams + await fallback Load Jobs BEFORE the
+    MERGE runs (order matters: rows must be durable in the temp first)."""
+    from target_bigquery.storage_write import BigQueryStorageWriteDenormalizedSink as SW
+    import target_bigquery.core as core
+
+    # BigQueryStorageWriteDenormalizedSink is not abstract (unlike
+    # BaseBigQuerySink), so __new__ works directly without a concrete subclass.
+    s = SW.__new__(SW)
+    calls = []
+    s.commit_streams = lambda: calls.append("commit")
+    s._wait_for_fallback_jobs = lambda: calls.append("fallback")
+    # Base checkpoint() (Task 1) records "merge"; patched via monkeypatch so
+    # it's restored automatically even if the assertion below fails.
+    monkeypatch.setattr(core.BaseBigQuerySink, "checkpoint", lambda self: calls.append("merge"))
+
+    SW.checkpoint(s)
+
+    assert calls == ["commit", "fallback", "merge"]

--- a/target_bigquery/tests/test_utils.py
+++ b/target_bigquery/tests/test_utils.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from typing import List
 
 import pytest
@@ -1000,17 +1001,39 @@ def test_storage_write_checkpoint_barrier_before_merge(monkeypatch):
     assert calls == ["commit", "fallback", "merge"]
 
 
+class _FakeSink:
+    """Minimal stand-in for a BaseBigQuerySink used only to carry
+    merge_target/overwrite_target for scope-gating checks (§5.3). Not a
+    MagicMock, since a MagicMock's un-configured attribute access returns a
+    truthy Mock rather than None, which would defeat the `is not None`
+    checks under test."""
+
+    def __init__(self, merge_target=None, overwrite_target=None):
+        self.merge_target = merge_target
+        self.overwrite_target = overwrite_target
+
+
 # --------------------------------------------------------------------------- #
 # checkpoint_row_threshold config + record counter + STATE trigger (PQ-3547)   #
 # --------------------------------------------------------------------------- #
-def _counter_target(threshold):
+def _counter_target(threshold, method="batch_job", sinks_active=None):
     from target_bigquery.target import TargetBigQuery
 
     t = TargetBigQuery.__new__(TargetBigQuery)
-    t._config = {"project": "p", "dataset": "d", "checkpoint_row_threshold": threshold}
+    t._config = {
+        "project": "p",
+        "dataset": "d",
+        "checkpoint_row_threshold": threshold,
+        "method": method,
+    }
     t._records_since_checkpoint = 0
     t._checkpoint_row_threshold = threshold
     t._latest_state = {"bookmarks": {}}
+    # Default: one eligible (upserting) sink, so threshold tests exercise only
+    # the counter/threshold logic. Scope-gating tests override this.
+    t._sinks_active = (
+        sinks_active if sinks_active is not None else {"A": _FakeSink(merge_target=object())}
+    )
     t.drain_all = MagicMock()
     return t
 
@@ -1054,6 +1077,100 @@ def test_record_message_increments_counter(monkeypatch):
     assert t._records_since_checkpoint == 1
 
 
+@pytest.mark.parametrize("threshold", [0, 1])
+def test_threshold_zero_checkpoints_every_boundary_positive_coalesces(monkeypatch, threshold):
+    import target_bigquery.target as tgt
+
+    monkeypatch.setattr(
+        tgt.TargetBigQuery.__mro__[1], "_process_state_message", lambda self, m: None
+    )
+    t = _counter_target(threshold=threshold)
+    t._records_since_checkpoint = 0
+    # threshold 0: 0 >= 0 -> every boundary checkpoints.
+    # threshold 1: 0 >= 1 is False -> this boundary does NOT checkpoint yet.
+    t._process_state_message({"type": "STATE", "value": {}})
+    if threshold == 0:
+        t.drain_all.assert_called_once_with(is_endofpipe=False)
+    else:
+        t.drain_all.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# row-threshold trigger scope gating (§5.3): only batch_job/storage_write_api #
+# with an active upsert (merge_target) sink, and never with an overwrite     #
+# sink, may take the mid-run row-threshold checkpoint path.                  #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("method", ["gcs_stage", "streaming_insert"])
+def test_no_row_threshold_checkpoint_for_out_of_scope_methods(monkeypatch, method):
+    import target_bigquery.target as tgt
+
+    monkeypatch.setattr(
+        tgt.TargetBigQuery.__mro__[1], "_process_state_message", lambda self, m: None
+    )
+    t = _counter_target(
+        threshold=0,
+        method=method,
+        sinks_active={"A": _FakeSink(merge_target=object())},
+    )
+    t._records_since_checkpoint = 0
+    t._process_state_message({"type": "STATE", "value": {}})
+    t.drain_all.assert_not_called()
+
+
+@pytest.mark.parametrize("method", ["batch_job", "storage_write_api"])
+def test_no_row_threshold_checkpoint_when_a_sink_is_overwrite_mode(monkeypatch, method):
+    import target_bigquery.target as tgt
+
+    monkeypatch.setattr(
+        tgt.TargetBigQuery.__mro__[1], "_process_state_message", lambda self, m: None
+    )
+    t = _counter_target(
+        threshold=0,
+        method=method,
+        sinks_active={
+            "A": _FakeSink(merge_target=object()),
+            "B": _FakeSink(overwrite_target=object()),
+        },
+    )
+    t._records_since_checkpoint = 0
+    t._process_state_message({"type": "STATE", "value": {}})
+    t.drain_all.assert_not_called()
+
+
+@pytest.mark.parametrize("method", ["batch_job", "storage_write_api"])
+def test_row_threshold_checkpoint_eligible_for_batch_job_and_storage_write_upsert(
+    monkeypatch, method
+):
+    import target_bigquery.target as tgt
+
+    monkeypatch.setattr(
+        tgt.TargetBigQuery.__mro__[1], "_process_state_message", lambda self, m: None
+    )
+    t = _counter_target(
+        threshold=0,
+        method=method,
+        sinks_active={"A": _FakeSink(merge_target=object())},
+    )
+    t._records_since_checkpoint = 0
+    t._process_state_message({"type": "STATE", "value": {}})
+    t.drain_all.assert_called_once_with(is_endofpipe=False)
+
+
+@pytest.mark.parametrize("method", ["batch_job", "storage_write_api"])
+def test_no_row_threshold_checkpoint_when_no_sink_is_upserting(monkeypatch, method):
+    """Pure append-mode sinks (no merge_target, no overwrite_target) are not
+    in scope either -- there is nothing for checkpoint()/MERGE to do."""
+    import target_bigquery.target as tgt
+
+    monkeypatch.setattr(
+        tgt.TargetBigQuery.__mro__[1], "_process_state_message", lambda self, m: None
+    )
+    t = _counter_target(threshold=0, method=method, sinks_active={"A": _FakeSink()})
+    t._records_since_checkpoint = 0
+    t._process_state_message({"type": "STATE", "value": {}})
+    t.drain_all.assert_not_called()
+
+
 # --------------------------------------------------------------------------- #
 # drain_all non-endofpipe path checkpoints (MERGE) + resets counter (PQ-3547) #
 # --------------------------------------------------------------------------- #
@@ -1081,53 +1198,79 @@ def test_drain_all_non_endofpipe_checkpoints_and_resets_counter():
 
 
 # --------------------------------------------------------------------------- #
-# per-stream checkpoint failure isolation + bookmark roll-back (PQ-3547)      #
+# fail-fast checkpoint finalization (PQ-3547 §5.2/§7): the first sink.checkpoint()
+# / sink.clean_up() failure propagates immediately with no try/except around
+# the sink loop. Earlier successful sinks in the same boundary are NOT rolled
+# back, but no STATE is written for that boundary and later sinks are not
+# finalized (fail-fast, not per-stream isolation).                            #
 # --------------------------------------------------------------------------- #
-def _isolation_target(sinks, is_endofpipe):
+def _failfast_target(sinks, is_endofpipe):
     from target_bigquery.target import TargetBigQuery
 
     t = TargetBigQuery.__new__(TargetBigQuery)
     t._config = {"project": "p", "dataset": "d"}
-    t._latest_state = {"bookmarks": {"A": {"v": 10}, "B": {"v": 20}}}
-    t._last_committed_state = {"bookmarks": {"A": {"v": 1}, "B": {"v": 2}}}
-    t._checkpoint_failures = set()
+    t._latest_state = {"bookmarks": {"A": 10, "B": 20, "C": 30}}
     t._sinks_active = sinks
     t.workers = []
     t.max_parallelism = 1
     t._delete_buffer = {}
-    t._records_since_checkpoint = 0
+    t._records_since_checkpoint = 42
     t._drain_all = MagicMock()
     t._raise_pending_worker_error = MagicMock()
     t._reset_max_record_age = MagicMock()
-    t._written = {}
-    t._write_state_message = lambda s: t._written.update(s)
+    t._write_state_message = MagicMock()
     return t
 
 
-def test_failed_stream_bookmark_rolled_back_others_advance():
-    good = MagicMock()
-    good.stream_name = "A"
-    bad = MagicMock()
-    bad.stream_name = "B"
-    bad.checkpoint.side_effect = Exception("merge failed")
-    t = _isolation_target({"A": good, "B": bad}, is_endofpipe=False)
+def test_state_written_after_fully_successful_checkpoint():
+    sinks = OrderedDict(A=MagicMock(), B=MagicMock(), C=MagicMock())
+    t = _failfast_target(sinks, is_endofpipe=False)
     t.drain_all(is_endofpipe=False)
-    # A advanced to latest, B rolled back to last committed
-    assert t._written["bookmarks"]["A"] == {"v": 10}
-    assert t._written["bookmarks"]["B"] == {"v": 2}
-    assert "B" in t._checkpoint_failures
+    for sink in sinks.values():
+        sink.checkpoint.assert_called_once()
+    t._write_state_message.assert_called_once_with({"bookmarks": {"A": 10, "B": 20, "C": 30}})
+    assert t._records_since_checkpoint == 0
 
 
-def test_endofpipe_raises_if_any_stream_failed():
-    from target_bigquery.target import CheckpointError
+def test_first_sink_failure_no_state_later_sinks_not_checkpointed():
+    sinks = OrderedDict(A=MagicMock(), B=MagicMock(), C=MagicMock())
+    sinks["A"].checkpoint.side_effect = Exception("merge failed")
+    t = _failfast_target(sinks, is_endofpipe=False)
+    with pytest.raises(Exception, match="merge failed"):
+        t.drain_all(is_endofpipe=False)
+    sinks["B"].checkpoint.assert_not_called()
+    sinks["C"].checkpoint.assert_not_called()
+    t._write_state_message.assert_not_called()
+    # Counter reset happens after the checkpoint loop, so a failure must skip it.
+    assert t._records_since_checkpoint == 42
 
-    good = MagicMock()
-    good.stream_name = "A"
-    bad = MagicMock()
-    bad.stream_name = "B"
-    bad.clean_up.side_effect = Exception("merge failed")
-    t = _isolation_target({"A": good, "B": bad}, is_endofpipe=True)
-    with pytest.raises(CheckpointError):
+
+def test_later_sink_failure_after_earlier_success_still_fails_fast():
+    sinks = OrderedDict(A=MagicMock(), B=MagicMock(), C=MagicMock())
+    sinks["B"].checkpoint.side_effect = Exception("merge failed")
+    t = _failfast_target(sinks, is_endofpipe=False)
+    with pytest.raises(Exception, match="merge failed"):
+        t.drain_all(is_endofpipe=False)
+    sinks["A"].checkpoint.assert_called_once()  # A already ran (not rolled back)
+    sinks["C"].checkpoint.assert_not_called()  # C never reached
+    t._write_state_message.assert_not_called()
+    assert t._records_since_checkpoint == 42  # not reset
+
+
+def test_endofpipe_clean_up_failure_prevents_final_state():
+    sinks = OrderedDict(A=MagicMock(), B=MagicMock())
+    sinks["B"].clean_up.side_effect = Exception("merge failed")
+    t = _failfast_target(sinks, is_endofpipe=True)
+    with pytest.raises(Exception, match="merge failed"):
         t.drain_all(is_endofpipe=True)
-    # state was still written (good stream A persisted) before raising
-    assert t._written["bookmarks"]["A"] == {"v": 10}
+    sinks["A"].clean_up.assert_called_once()
+    t._write_state_message.assert_not_called()
+
+
+def test_endofpipe_fully_successful_clean_up_writes_final_state():
+    sinks = OrderedDict(A=MagicMock(), B=MagicMock())
+    t = _failfast_target(sinks, is_endofpipe=True)
+    t.drain_all(is_endofpipe=True)
+    for sink in sinks.values():
+        sink.clean_up.assert_called_once()
+    t._write_state_message.assert_called_once_with({"bookmarks": {"A": 10, "B": 20, "C": 30}})

--- a/target_bigquery/tests/test_utils.py
+++ b/target_bigquery/tests/test_utils.py
@@ -1498,3 +1498,190 @@ def test_drain_all_non_endofpipe_eligible_checkpoint_failure_fails_fast():
         t.drain_all(is_endofpipe=False)
     t._write_state_message.assert_not_called()
     assert t._records_since_checkpoint == 42  # not reset
+
+
+# --------------------------------------------------------------------------- #
+# P0 (PQ-3547): a worker/load error must NEVER emit STATE.                     #
+#                                                                             #
+# The old drain_one() error branch recv()'d the worker error (consuming it)   #
+# then called drain_all(is_endofpipe=True). Inside that nested drain,         #
+# _raise_pending_worker_error found the pipe already empty and fell through   #
+# to clean_up() + _write_state_message(), emitting the advanced bookmark      #
+# BEFORE drain_one finally re-raised -> STATE advanced past a failed batch =   #
+# data loss on resume. The fix tears down worker PROCESSES ONLY               #
+# (_shutdown_workers) on the error path and never finalizes sinks or state.   #
+# --------------------------------------------------------------------------- #
+class _FakePipe:
+    """Minimal Connection stand-in. poll() returns queued booleans (then False);
+    recv() returns a fixed payload. Not a MagicMock, so poll()'s truthiness is
+    exactly what we script."""
+
+    def __init__(self, poll_results=(), recv_value=None):
+        self._poll = list(poll_results)
+        self._recv_value = recv_value
+
+    def poll(self):
+        if self._poll:
+            return self._poll.pop(0)
+        return False
+
+    def recv(self):
+        return self._recv_value
+
+
+def test_worker_error_never_emits_state_through_real_drain_path():
+    """The strongest P0 regression: drive the REAL TargetBigQuery.drain_all
+    (is_endofpipe=False) and let the REAL singer-sdk _drain_all() call the REAL
+    drain_one(), whose error poll fires. _drain_all/drain_one are NOT mocked.
+    A worker error must propagate as RuntimeError with workers torn down and
+    ZERO sink finalization / STATE emission -- the previously-emitted bookmark
+    stays the last output."""
+    from target_bigquery.target import TargetBigQuery
+
+    t = TargetBigQuery.__new__(TargetBigQuery)
+    t._config = {"project": "p", "dataset": "d", "fail_fast": True}
+    t._latest_state = {"bookmarks": {"A": 7}}  # already emitted; must not advance
+    t.max_parallelism = 1
+    # logger is a read-only classproperty in the SDK; the real one logs fine.
+    t._delete_buffer = {}
+
+    # Fake pipes: only the error pipe fires (once).
+    t.job_notification = _FakePipe([False])
+    t.log_notification = _FakePipe([False])
+    original_error = RuntimeError("record too large for any AppendRows request")
+    t.error_notification = _FakePipe([True], recv_value=(original_error, "worker load failed"))
+
+    # Fake queue + one alive worker so the real _shutdown_workers has work to do.
+    t.queue = MagicMock()
+    worker = MagicMock()
+    worker.is_alive.return_value = True
+    t.workers = [worker]
+
+    # resize_worker_pool would otherwise spawn a real thread; neutralize only it.
+    t.resize_worker_pool = MagicMock()
+
+    sink = MagicMock()
+    t._sinks_active = {"A": sink}
+
+    # Record-only spies; drain_one() and _drain_all() stay REAL.
+    t._flush_deletes = MagicMock()
+    t._write_state_message = MagicMock()
+    t._reset_max_record_age = MagicMock()
+
+    with pytest.raises(RuntimeError):
+        t.drain_all(is_endofpipe=False)
+
+    # _shutdown_workers ran on the real path: sentinel queued, worker joined, list cleared.
+    t.queue.put.assert_called_once_with(None)
+    worker.join.assert_called_once()
+    assert t.workers == []
+    # Absolutely no sink finalization or STATE emission on the error path.
+    sink.clean_up.assert_not_called()
+    sink.checkpoint.assert_not_called()
+    t._flush_deletes.assert_not_called()
+    t._write_state_message.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# _shutdown_workers(): worker PROCESS teardown only (no sinks/state).          #
+# --------------------------------------------------------------------------- #
+def test_shutdown_workers_sends_sentinels_joins_once_and_clears():
+    from target_bigquery.target import TargetBigQuery
+
+    t = TargetBigQuery.__new__(TargetBigQuery)
+    t.queue = MagicMock()
+    workers = [MagicMock() for _ in range(3)]
+    for w in workers:
+        w.is_alive.return_value = True
+    t.workers = list(workers)
+
+    t._shutdown_workers()
+
+    # One sentinel per alive worker.
+    assert t.queue.put.call_count == 3
+    assert all(c.args == (None,) for c in t.queue.put.call_args_list)
+    # Every worker joined exactly once (no double-join, no skipped first).
+    for w in workers:
+        w.join.assert_called_once()
+    assert t.workers == []
+
+
+def test_shutdown_workers_is_noop_safe_on_empty_list():
+    from target_bigquery.target import TargetBigQuery
+
+    t = TargetBigQuery.__new__(TargetBigQuery)
+    t.queue = MagicMock()
+    t.workers = []
+    t._shutdown_workers()  # must not raise
+    t.queue.put.assert_not_called()
+    assert t.workers == []
+
+
+# --------------------------------------------------------------------------- #
+# P2 (PQ-3547): overwrite exclusion is RUN-LEVEL on the mid-run drain.         #
+# If ANY active sink is in overwrite mode, NO sink is checkpointed -- every    #
+# sink uses pre_state_hook() (origin/master behavior) and STATE is emitted.    #
+# --------------------------------------------------------------------------- #
+def test_drain_all_non_endofpipe_mixed_upsert_and_overwrite_none_checkpoint():
+    upsert = _checkpoint_mock_sink(merge_target=object())
+    overwrite = _checkpoint_mock_sink(overwrite_target=object())
+    t = _drain_target(OrderedDict(A=upsert, B=overwrite), method="batch_job")
+    t.drain_all(is_endofpipe=False)
+    # Run-level gate: coexisting overwrite target excludes the whole run.
+    upsert.checkpoint.assert_not_called()
+    overwrite.checkpoint.assert_not_called()
+    upsert.pre_state_hook.assert_called_once()
+    overwrite.pre_state_hook.assert_called_once()
+    t._write_state_message.assert_called_once()  # STATE still emitted
+
+
+# --------------------------------------------------------------------------- #
+# Batch Job destination resolves self.table.as_ref() per enqueue, so a Job     #
+# enqueued BEFORE a checkpoint carries the generation-1 table and one enqueued #
+# AFTER carries generation-2 (rotated staging table). Uses the __new__-based   #
+# no-BQ sink helper + a recording queue; the MERGE and staging-table creation  #
+# inside checkpoint() are stubbed (no real infra), and rotation is emulated by #
+# swapping self.table -- faithful to how checkpoint() rotates staging.         #
+# --------------------------------------------------------------------------- #
+def test_batch_job_destination_before_and_after_checkpoint_rotation(monkeypatch):
+    from target_bigquery.batch_job import BigQueryBatchJobSink
+    from target_bigquery.core import BigQueryTable, IngestionStrategy, Compressor, ParType
+
+    opts = {
+        "project": "p", "dataset": "d", "jsonschema": {"properties": {}},
+        "transforms": {}, "ingestion_strategy": IngestionStrategy.FIXED,
+    }
+    gen1 = BigQueryTable(name="orders__gen1_1", **opts)
+    gen2 = BigQueryTable(name="orders__gen2_1", **opts)
+
+    s = BigQueryBatchJobSink.__new__(BigQueryBatchJobSink)
+    s.client = MagicMock()
+    s.merge_target = BigQueryTable(name="orders", **opts)
+    s.table = gen1
+    s.buffer = Compressor()
+    s.global_par_typ = ParType.THREAD
+    s.increment_jobs_enqueued = lambda: None
+
+    enqueued = []
+    s.global_queue = MagicMock()
+    s.global_queue.put.side_effect = lambda job: enqueued.append(job)
+
+    # REAL process_batch resolves self.table.as_ref() at enqueue time.
+    s.process_batch({})  # BEFORE checkpoint -> generation 1
+
+    # Stub the destructive halves of checkpoint(): MERGE issues a query; the
+    # staging rotation swaps self.table to generation 2 (no real BQ table).
+    monkeypatch.setattr(
+        type(s), "_merge_staging_into_target", lambda self: self.client.query("MERGE")
+    )
+    monkeypatch.setattr(
+        type(s), "_new_staging_table", lambda self: setattr(self, "table", gen2)
+    )
+    s.checkpoint()
+
+    s.process_batch({})  # AFTER checkpoint -> generation 2
+
+    assert len(enqueued) == 2
+    assert enqueued[0].table == gen1.as_ref()
+    assert enqueued[1].table == gen2.as_ref()
+    assert enqueued[0].table != enqueued[1].table

--- a/target_bigquery/tests/test_utils.py
+++ b/target_bigquery/tests/test_utils.py
@@ -1078,3 +1078,56 @@ def test_drain_all_non_endofpipe_checkpoints_and_resets_counter():
     sink.clean_up.assert_not_called()  # not a teardown
     assert t._records_since_checkpoint == 0  # window reset
     t._write_state_message.assert_called_once()
+
+
+# --------------------------------------------------------------------------- #
+# per-stream checkpoint failure isolation + bookmark roll-back (PQ-3547)      #
+# --------------------------------------------------------------------------- #
+def _isolation_target(sinks, is_endofpipe):
+    from target_bigquery.target import TargetBigQuery
+
+    t = TargetBigQuery.__new__(TargetBigQuery)
+    t._config = {"project": "p", "dataset": "d"}
+    t._latest_state = {"bookmarks": {"A": {"v": 10}, "B": {"v": 20}}}
+    t._last_committed_state = {"bookmarks": {"A": {"v": 1}, "B": {"v": 2}}}
+    t._checkpoint_failures = set()
+    t._sinks_active = sinks
+    t.workers = []
+    t.max_parallelism = 1
+    t._delete_buffer = {}
+    t._records_since_checkpoint = 0
+    t._drain_all = MagicMock()
+    t._raise_pending_worker_error = MagicMock()
+    t._reset_max_record_age = MagicMock()
+    t._written = {}
+    t._write_state_message = lambda s: t._written.update(s)
+    return t
+
+
+def test_failed_stream_bookmark_rolled_back_others_advance():
+    good = MagicMock()
+    good.stream_name = "A"
+    bad = MagicMock()
+    bad.stream_name = "B"
+    bad.checkpoint.side_effect = Exception("merge failed")
+    t = _isolation_target({"A": good, "B": bad}, is_endofpipe=False)
+    t.drain_all(is_endofpipe=False)
+    # A advanced to latest, B rolled back to last committed
+    assert t._written["bookmarks"]["A"] == {"v": 10}
+    assert t._written["bookmarks"]["B"] == {"v": 2}
+    assert "B" in t._checkpoint_failures
+
+
+def test_endofpipe_raises_if_any_stream_failed():
+    from target_bigquery.target import CheckpointError
+
+    good = MagicMock()
+    good.stream_name = "A"
+    bad = MagicMock()
+    bad.stream_name = "B"
+    bad.clean_up.side_effect = Exception("merge failed")
+    t = _isolation_target({"A": good, "B": bad}, is_endofpipe=True)
+    with pytest.raises(CheckpointError):
+        t.drain_all(is_endofpipe=True)
+    # state was still written (good stream A persisted) before raising
+    assert t._written["bookmarks"]["A"] == {"v": 10}

--- a/target_bigquery/tests/test_utils.py
+++ b/target_bigquery/tests/test_utils.py
@@ -1052,3 +1052,29 @@ def test_record_message_increments_counter(monkeypatch):
     t = _counter_target(threshold=1000)
     t._process_record_message({"type": "RECORD", "stream": "A", "record": {}})
     assert t._records_since_checkpoint == 1
+
+
+# --------------------------------------------------------------------------- #
+# drain_all non-endofpipe path checkpoints (MERGE) + resets counter (PQ-3547) #
+# --------------------------------------------------------------------------- #
+def test_drain_all_non_endofpipe_checkpoints_and_resets_counter():
+    from target_bigquery.target import TargetBigQuery
+
+    t = TargetBigQuery.__new__(TargetBigQuery)
+    t._config = {"project": "p", "dataset": "d"}
+    t._latest_state = {"bookmarks": {"A": 5}}
+    sink = MagicMock()
+    t._sinks_active = {"A": sink}
+    t.workers = []
+    t.max_parallelism = 1
+    t._delete_buffer = {}
+    t._records_since_checkpoint = 42
+    t._drain_all = MagicMock()
+    t._raise_pending_worker_error = MagicMock()
+    t._write_state_message = MagicMock()
+    t._reset_max_record_age = MagicMock()
+    t.drain_all(is_endofpipe=False)
+    sink.checkpoint.assert_called_once()  # MERGE ran mid-run
+    sink.clean_up.assert_not_called()  # not a teardown
+    assert t._records_since_checkpoint == 0  # window reset
+    t._write_state_message.assert_called_once()

--- a/target_bigquery/tests/test_utils.py
+++ b/target_bigquery/tests/test_utils.py
@@ -894,3 +894,83 @@ def test_flush_skips_empty_record_lists():
     t, client = _run_flush({"Accounts": []})
     client.query.assert_not_called()
     assert t._delete_buffer == {}
+
+
+# --------------------------------------------------------------------------- #
+# checkpoint() — mid-run MERGE (PQ-3547)                                        #
+# --------------------------------------------------------------------------- #
+from copy import copy as _copy
+
+
+def _merge_sink():
+    """A BaseBigQuerySink-like object with merge staging, no __init__/BQ."""
+    from target_bigquery.core import BaseBigQuerySink, BigQueryTable, IngestionStrategy
+
+    # BaseBigQuerySink is abstract (process_batch/worker_cls_factory), so
+    # object.__new__ refuses to instantiate it directly. A trivial concrete
+    # subclass sidesteps that without changing any inherited behavior we
+    # exercise here (checkpoint()/_new_staging_table() are defined on the
+    # base class itself).
+    class _ConcreteSink(BaseBigQuerySink):
+        def process_batch(self, context):
+            raise NotImplementedError
+
+        @staticmethod
+        def worker_cls_factory(worker_executor_cls, config):
+            raise NotImplementedError
+
+    s = _ConcreteSink.__new__(_ConcreteSink)
+    s.client = MagicMock()
+    s.stream_name = "SalesInvoiceLines"
+    s._key_properties = ["id"]  # key_properties is a read-only property in the SDK base
+    s._config = {"project": "p", "dataset": "d"}  # config is also a read-only property
+    opts = {
+        "project": "p", "dataset": "d", "jsonschema": {"properties": {}},
+        "transforms": {}, "ingestion_strategy": IngestionStrategy.DENORMALIZED,
+    }
+    s._staging_opts = opts
+    s._staging_seq = 0
+    real = BigQueryTable(name="salesinvoicelines", **opts)
+    s.merge_target = _copy(real)
+    s.table = BigQueryTable(name="salesinvoicelines__100", **opts)
+    # apply_transforms is a read-only property (derived from ingestion_strategy)
+    # and is unused by checkpoint()/_merge_staging_into_target(); not set here.
+    return s
+
+
+def test_checkpoint_merges_and_rotates_temp_without_teardown(monkeypatch):
+    s = _merge_sink()
+    # stub dedupe/merge to avoid building real SQL/schema
+    monkeypatch.setattr(type(s), "_is_dedupe_before_upsert_candidate", lambda self: False)
+    created = []
+    monkeypatch.setattr(type(s), "_new_staging_table",
+                        lambda self: created.append(True))
+    prev_target = s.merge_target
+    s.checkpoint()
+    assert s.client.query.called                 # a MERGE was issued
+    assert created == [True]                      # fresh temp rotated in
+    assert s.merge_target is prev_target          # merge_target NOT torn down
+
+
+def test_checkpoint_raises_and_does_not_drop_on_merge_failure(monkeypatch):
+    s = _merge_sink()
+    monkeypatch.setattr(type(s), "_is_dedupe_before_upsert_candidate", lambda self: False)
+    monkeypatch.setattr(type(s), "_new_staging_table", lambda self: None)
+    s.client.query.side_effect = Exception("schema mismatch")
+    with pytest.raises(Exception):
+        s.checkpoint()
+    # Exactly one query call was made (the failed MERGE attempt) and no
+    # separate standalone DROP-only query was issued afterward. (The old
+    # buggy code issued a second "DROP TABLE IF EXISTS ..." query in its
+    # except clause; merge_sql itself legitimately ENDS with a DROP TABLE
+    # statement, so asserting on substring "DROP TABLE" would be wrong here.)
+    assert s.client.query.call_count == 1
+
+
+def test_checkpoint_noop_when_no_merge_target(monkeypatch):
+    s = _merge_sink()
+    s.merge_target = None
+    monkeypatch.setattr(type(s), "_new_staging_table",
+                        lambda self: (_ for _ in ()).throw(AssertionError("rotated")))
+    s.checkpoint()                                # must not raise / not rotate
+    assert not s.client.query.called

--- a/target_bigquery/tests/test_utils.py
+++ b/target_bigquery/tests/test_utils.py
@@ -998,3 +998,57 @@ def test_storage_write_checkpoint_barrier_before_merge(monkeypatch):
     SW.checkpoint(s)
 
     assert calls == ["commit", "fallback", "merge"]
+
+
+# --------------------------------------------------------------------------- #
+# checkpoint_row_threshold config + record counter + STATE trigger (PQ-3547)   #
+# --------------------------------------------------------------------------- #
+def _counter_target(threshold):
+    from target_bigquery.target import TargetBigQuery
+
+    t = TargetBigQuery.__new__(TargetBigQuery)
+    t._config = {"project": "p", "dataset": "d", "checkpoint_row_threshold": threshold}
+    t._records_since_checkpoint = 0
+    t._checkpoint_row_threshold = threshold
+    t._latest_state = {"bookmarks": {}}
+    t.drain_all = MagicMock()
+    return t
+
+
+def test_state_message_triggers_checkpoint_when_threshold_met(monkeypatch):
+    import target_bigquery.target as tgt
+
+    # Target (TargetBigQuery.__mro__[1]) defines the SDK base
+    # _process_state_message; stub it so our override's own logic (call
+    # super() then evaluate the trigger) is what's under test.
+    assert tgt.TargetBigQuery.__mro__[1].__name__ == "Target"
+    monkeypatch.setattr(
+        tgt.TargetBigQuery.__mro__[1], "_process_state_message", lambda self, m: None
+    )
+    t = _counter_target(threshold=3)
+    t._records_since_checkpoint = 3
+    t._process_state_message({"type": "STATE", "value": {"bookmarks": {"A": 1}}})
+    t.drain_all.assert_called_once_with(is_endofpipe=False)
+
+
+def test_state_message_no_checkpoint_below_threshold(monkeypatch):
+    import target_bigquery.target as tgt
+
+    monkeypatch.setattr(
+        tgt.TargetBigQuery.__mro__[1], "_process_state_message", lambda self, m: None
+    )
+    t = _counter_target(threshold=1000)
+    t._records_since_checkpoint = 10
+    t._process_state_message({"type": "STATE", "value": {}})
+    t.drain_all.assert_not_called()
+
+
+def test_record_message_increments_counter(monkeypatch):
+    import target_bigquery.target as tgt
+
+    monkeypatch.setattr(
+        tgt.TargetBigQuery.__mro__[1], "_process_record_message", lambda self, m: None
+    )
+    t = _counter_target(threshold=1000)
+    t._process_record_message({"type": "RECORD", "stream": "A", "record": {}})
+    assert t._records_since_checkpoint == 1

--- a/target_bigquery/tests/test_utils.py
+++ b/target_bigquery/tests/test_utils.py
@@ -1293,13 +1293,26 @@ def test_no_row_threshold_checkpoint_when_no_sink_is_upserting(monkeypatch, meth
 # --------------------------------------------------------------------------- #
 # drain_all non-endofpipe path checkpoints (MERGE) + resets counter (PQ-3547) #
 # --------------------------------------------------------------------------- #
+def _checkpoint_mock_sink(merge_target=None, overwrite_target=None):
+    """A MagicMock sink with *real* merge_target/overwrite_target values.
+
+    A bare MagicMock's un-configured attribute is a truthy Mock (never None),
+    which would defeat the `merge_target is not None` / `overwrite_target is
+    None` scope checks the drain_all gate makes per sink. Setting them to real
+    values (object() or None) lets the eligibility predicate behave."""
+    s = MagicMock()
+    s.merge_target = merge_target
+    s.overwrite_target = overwrite_target
+    return s
+
+
 def test_drain_all_non_endofpipe_checkpoints_and_resets_counter():
     from target_bigquery.target import TargetBigQuery
 
     t = TargetBigQuery.__new__(TargetBigQuery)
     t._config = {"project": "p", "dataset": "d"}
     t._latest_state = {"bookmarks": {"A": 5}}
-    sink = MagicMock()
+    sink = _checkpoint_mock_sink(merge_target=object())  # eligible: upsert sink
     t._sinks_active = {"A": sink}
     t.workers = []
     t.max_parallelism = 1
@@ -1342,7 +1355,11 @@ def _failfast_target(sinks, is_endofpipe):
 
 
 def test_state_written_after_fully_successful_checkpoint():
-    sinks = OrderedDict(A=MagicMock(), B=MagicMock(), C=MagicMock())
+    sinks = OrderedDict(
+        A=_checkpoint_mock_sink(merge_target=object()),
+        B=_checkpoint_mock_sink(merge_target=object()),
+        C=_checkpoint_mock_sink(merge_target=object()),
+    )
     t = _failfast_target(sinks, is_endofpipe=False)
     t.drain_all(is_endofpipe=False)
     for sink in sinks.values():
@@ -1352,7 +1369,11 @@ def test_state_written_after_fully_successful_checkpoint():
 
 
 def test_first_sink_failure_no_state_later_sinks_not_checkpointed():
-    sinks = OrderedDict(A=MagicMock(), B=MagicMock(), C=MagicMock())
+    sinks = OrderedDict(
+        A=_checkpoint_mock_sink(merge_target=object()),
+        B=_checkpoint_mock_sink(merge_target=object()),
+        C=_checkpoint_mock_sink(merge_target=object()),
+    )
     sinks["A"].checkpoint.side_effect = Exception("merge failed")
     t = _failfast_target(sinks, is_endofpipe=False)
     with pytest.raises(Exception, match="merge failed"):
@@ -1365,7 +1386,11 @@ def test_first_sink_failure_no_state_later_sinks_not_checkpointed():
 
 
 def test_later_sink_failure_after_earlier_success_still_fails_fast():
-    sinks = OrderedDict(A=MagicMock(), B=MagicMock(), C=MagicMock())
+    sinks = OrderedDict(
+        A=_checkpoint_mock_sink(merge_target=object()),
+        B=_checkpoint_mock_sink(merge_target=object()),
+        C=_checkpoint_mock_sink(merge_target=object()),
+    )
     sinks["B"].checkpoint.side_effect = Exception("merge failed")
     t = _failfast_target(sinks, is_endofpipe=False)
     with pytest.raises(Exception, match="merge failed"):
@@ -1393,3 +1418,83 @@ def test_endofpipe_fully_successful_clean_up_writes_final_state():
     for sink in sinks.values():
         sink.clean_up.assert_called_once()
     t._write_state_message.assert_called_once_with({"bookmarks": {"A": 10, "B": 20, "C": 30}})
+
+
+# --------------------------------------------------------------------------- #
+# drain_all(is_endofpipe=False) per-sink scope gate (PQ-3547 §5.3/§10).        #
+#                                                                             #
+# singer-sdk's _handle_max_record_age() calls drain_all(is_endofpipe=False)   #
+# directly on a wall-clock timer, bypassing the _process_state_message trigger #
+# gate entirely. So the scope gate MUST also live inside drain_all's mid-run  #
+# branch, per sink: eligible (batch_job/storage_write upsert) sinks MERGE via #
+# checkpoint(); everything else (gcs_stage/streaming_insert/overwrite) keeps  #
+# its origin/master pre_state_hook() behavior so a mid-run drain can't MERGE  #
+# an empty staging table and advance the bookmark past GCS-only data.         #
+# --------------------------------------------------------------------------- #
+def _drain_target(sinks, method="storage_write_api"):
+    """A __init__-less TargetBigQuery wired for drain_all() mid-run tests."""
+    from target_bigquery.target import TargetBigQuery
+
+    t = TargetBigQuery.__new__(TargetBigQuery)
+    t._config = {"project": "p", "dataset": "d", "method": method}
+    t._latest_state = {"bookmarks": {"A": 5}}
+    t._sinks_active = sinks
+    t.workers = []
+    t.max_parallelism = 1
+    t._delete_buffer = {}
+    t._records_since_checkpoint = 42
+    t._drain_all = MagicMock()
+    t._raise_pending_worker_error = MagicMock()
+    t._write_state_message = MagicMock()
+    t._reset_max_record_age = MagicMock()
+    return t
+
+
+def test_drain_all_non_endofpipe_ineligible_method_uses_pre_state_hook():
+    # method=gcs_stage: even a sink with merge_target set is OUT of scope. The
+    # mid-run (max-age) drain must fall back to the origin/master pre_state_hook
+    # and must NOT checkpoint (which would MERGE an empty staging table and
+    # advance the bookmark past GCS-only data). STATE is still emitted.
+    sink = _checkpoint_mock_sink(merge_target=object())
+    t = _drain_target({"A": sink}, method="gcs_stage")
+    t.drain_all(is_endofpipe=False)
+    sink.pre_state_hook.assert_called_once()
+    sink.checkpoint.assert_not_called()
+    t._write_state_message.assert_called_once()
+
+
+def test_drain_all_non_endofpipe_overwrite_sink_uses_pre_state_hook():
+    # Overwrite sink under batch_job: eligible method, but overwrite_target set
+    # (and merge_target None) => out of scope. pre_state_hook, not checkpoint.
+    sink = _checkpoint_mock_sink(overwrite_target=object())
+    t = _drain_target({"A": sink}, method="batch_job")
+    t.drain_all(is_endofpipe=False)
+    sink.pre_state_hook.assert_called_once()
+    sink.checkpoint.assert_not_called()
+    t._write_state_message.assert_called_once()
+
+
+@pytest.mark.parametrize("method", ["batch_job", "storage_write_api"])
+def test_drain_all_non_endofpipe_eligible_sink_checkpoints(method):
+    # Eligible: batch_job/storage_write upsert sink (merge_target set, no
+    # overwrite) => checkpoint() MERGEs mid-run, pre_state_hook is not used,
+    # the record counter resets, and STATE is emitted.
+    sink = _checkpoint_mock_sink(merge_target=object())
+    t = _drain_target({"A": sink}, method=method)
+    t.drain_all(is_endofpipe=False)
+    sink.checkpoint.assert_called_once()
+    sink.pre_state_hook.assert_not_called()
+    assert t._records_since_checkpoint == 0
+    t._write_state_message.assert_called_once()
+
+
+def test_drain_all_non_endofpipe_eligible_checkpoint_failure_fails_fast():
+    # Fail-fast still holds on the gated mid-run path: an eligible sink whose
+    # checkpoint() raises propagates before STATE and before the counter reset.
+    sink = _checkpoint_mock_sink(merge_target=object())
+    sink.checkpoint.side_effect = Exception("merge failed")
+    t = _drain_target({"A": sink}, method="batch_job")
+    with pytest.raises(Exception, match="merge failed"):
+        t.drain_all(is_endofpipe=False)
+    t._write_state_message.assert_not_called()
+    assert t._records_since_checkpoint == 42  # not reset


### PR DESCRIPTION
## Reference Ticket
- PQ-3547

## Description
Persists Singer bookmarks *during* a run, so a pipeline killed mid-run (pod eviction / OOM) resumes from the last completed checkpoint instead of restarting from zero — and stops a failed MERGE from silently dropping data.

- MERGEs staged data into the real table at table/category boundaries (row threshold `checkpoint_row_threshold`, default 10000; `0` = every boundary), then emits STATE — so a bookmark never advances past data that isn't durable yet.
- A failed MERGE now raises instead of dropping the staging table and advancing the bookmark (removes a pre-existing silent-data-loss path). Fail-fast: no STATE is emitted for a failed checkpoint and the run exits non-zero.
- Supports `batch_job` and Storage Write (`_default`, which rotates its write stream with the staging table on each checkpoint). `gcs_stage`, `streaming_insert` and overwrite mode keep their existing behavior.

## Companion PRs
- target-postgres: https://github.com/Peliqan-io/target-postgres/pull/30
- baserow: https://github.com/Peliqan-io/baserow/pull/5664
